### PR TITLE
fix: make sure the host function delegate is not garbage collected

### DIFF
--- a/test/Extism.Sdk/BasicTests.cs
+++ b/test/Extism.Sdk/BasicTests.cs
@@ -114,20 +114,23 @@ public class BasicTests
     [Fact]
     public void CountVowelsHostFunctions()
     {
-        var userData = Marshal.StringToHGlobalAnsi("Hello again!");
+        for (int i = 0; i < 100; i++)
+        {
+            var userData = Marshal.StringToHGlobalAnsi("Hello again!");
 
-        using var helloWorld = new HostFunction(
-            "hello_world",
-            "env",
-            new[] { ExtismValType.I64 },
-            new[] { ExtismValType.I64 },
-            userData,
-            HelloWorld);
+            using var helloWorld = new HostFunction(
+                "hello_world",
+                "env",
+                new[] { ExtismValType.I64 },
+                new[] { ExtismValType.I64 },
+                userData,
+                HelloWorld);
 
-        using var plugin = Helpers.LoadPlugin("code-functions.wasm", config: null, helloWorld);
+            using var plugin = Helpers.LoadPlugin("code-functions.wasm", config: null, helloWorld);
 
-        var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"));
-        Encoding.UTF8.GetString(response).ShouldBe("{\"count\": 3}");
+            var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"));
+            Encoding.UTF8.GetString(response).ShouldBe("{\"count\": 3}");
+        }
 
         void HelloWorld(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs, nint data)
         {


### PR DESCRIPTION
We are now referencing the delegate in a field so that it lives as long as the host function is around. The test I changed now reproduces the issue 100% of the time