### PR TITLE
fix: change ExtismValType size to 4 bytes

### DIFF
--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -36,7 +36,7 @@ public struct ExtismValUnion
 /// <summary>
 /// Represents Wasm data types that Extism can understand
 /// </summary>
-public enum ExtismValType : byte
+public enum ExtismValType : int
 {
     /// <summary>
     /// Signed 32 bit integer. Equivalent of <see cref="int"/> or <see cref="uint"/>


### PR DESCRIPTION
I don't understand why this happens exactly, but it seems like when passing ExtismValType array to `extism_function_new`, it expects each element to be 4 bytes (which doesn't make sense, because the rust compiler tells me the ExtismValType is only one byte).

Repro:

```csharp
new HostFunction("kv_write", "env", 
    new ExtismValType[] { ExtismValType.F64, ExtismValType.F64, ExtismValType.F32, ExtismValType.I64 }, 
    new ExtismValType[]{}, IntPtr.Zero, (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
    {

    }),
```

Output:
```
Unhandled exception. Extism.Sdk.Native.ExtismException: Unable to create plugin: incompatible import type for `env::kv_write`

Caused by:
    function types incompatible: expected func of type `(i64, i64) -> ()`, found func of type `(f64, i32, i32, i32) -> ()`
   at Extism.Sdk.Native.Plugin.Initialize(Byte* wasmPtr, Int32 wasmLength, HostFunction[] functions, Boolean withWasi, IntPtr* functionsPtr) in D:\dylibso\dotnet-sdk\src\Extism.Sdk\Plugin.cs:line 91
   at Extism.Sdk.Native.Plugin..ctor(Manifest manifest, HostFunction[] functions, Boolean withWasi) in D:\dylibso\dotnet-sdk\src\Extism.Sdk\Plugin.cs:line 51
   at Program.<Main>$(String[] args) in D:\dylibso\dotnet-sdk\samples\Extism.Sdk.Sample\Program.cs:line 48
```

and if you change `extism_function_new` to add a println:
```rust
    let inputs = if inputs.is_null() || n_inputs == 0 {
        &[]
    } else {
        std::slice::from_raw_parts(inputs, n_inputs as usize)
    }
    .to_vec();

    println!("Hello world, here are the inputs: {}", n_inputs);
    for (index, val_type) in inputs.iter().enumerate() {
        println!("Input{}: Value: {:?}", index, val_type);
    }
```

Then, there is an access violation exception:
```
Hello world, here are the inputs: 4
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
Repeat 2 times:
--------------------------------
   at Extism.Sdk.Native.LibExtism.extism_function_new(System.String, Void*, Int64, Void*, Int64, InternalExtismFunction, IntPtr, IntPtr)
--------------------------------
   at Extism.Sdk.HostFunction..ctor(System.String, System.String, System.Span`1<Extism.Sdk.Native.ExtismValType>, System.Span`1<Extism.Sdk.Native.ExtismValType>, IntPtr, Extism.Sdk.ExtismFunction)
   at Program.<Main>$(System.String[])
```