### PR TITLE
update readme and make the API more convenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,39 @@
 # Extism .NET Host SDK
 
-> **Note**: This houses the 1.0 version of the .NET SDK and is a work in progress. Please use the .NET SDK in extism/extism until we hit 1.0.
-
 This repo houses the .NET SDK for integrating with the [Extism](https://extism.org/) runtime. Install this library into your host .NET applications to run Extism plugins.
+
+> **Note:** If you're unsure what Extism is or what an SDK is see our homepage: https://extism.org.
+
+> **Note**: This houses the 1.0 version of the .NET SDK and is a work in progress. Please use the .NET SDK in extism/extism until we hit 1.0.
 
 ## Installation
 
-You first need to [install the Extism runtime](https://extism.org/docs/install).
+For this library, you first need to install the Extism Runtime.
 
-> **__NOTE:__** We provide a native package for Windows. You can install with:
+### Windows
+
+We provide [a native package](https://www.nuget.org/packages/Extism.runtime.win-x64) for Windows. You can install with:
 > ```
 > dotnet add package Extism.runtime.win-64
 >```
 
-Add this NuGet package to your project:
+### Linux and macOS
+
+You can [download the shared object directly from a release](https://github.com/extism/extism/releases) or use the [Extism CLI](https://github.com/extism/cli) to install it:
+
+```
+sudo extism lib install latest
+
+#=> Fetching https://github.com/extism/extism/releases/download/v0.5.2/libextism-aarch64-apple-darwin-v0.5.2.tar.gz
+#=> Copying libextism.dylib to /usr/local/lib/libextism.dylib
+#=> Copying extism.h to /usr/local/include/extism.h
+```
+
+> Note: This library has breaking changes and targets 1.0 of the runtime. For the time being, install the runtime from our nightly development builds on git: sudo extism lib install --version git.
+
+### Install the NuGet package
+
+Add this [NuGet package](https://www.nuget.org/packages/Extism.Sdk) to your project:
 
 ```
 dotnet add package Extism.Sdk
@@ -21,36 +41,62 @@ dotnet add package Extism.Sdk
 
 ## Getting Started
 
+This guide should walk you through some of the concepts in Extism and this .NET library.
+
 First you should add a using statement for Extism:
 
-```
+C#:
+```csharp
 using Extism.Sdk;
 using Extism.Sdk.Native;
 ```
 
+F#:
+```
+open Extism.Sdk
+open Extism.Sdk.Native
+```
+
 ## Creating A Plug-in
 
-The primary concept in Extism is the plug-in. You can think of a plug-in as a code module. It has imports and it has exports. These imports and exports define the interface, or your API. You decide what they are called and typed, and what they do. Then the plug-in developer implements them and you can call them.
+The primary concept in Extism is the [plug-in](https://extism.org/docs/concepts/plug-in). You can think of a plug-in as a code module stored in a `.wasm` file.
 
-The code for a plug-in exist as a binary wasm module. We can load this with the raw bytes or we can use the manifest to tell Extism how to load it from disk or the web.
+Since you may not have an Extism plug-in on hand to test, let's load a demo plug-in from the web:
 
-For simplicity let's load one from the web:
-
+C#:
 ```csharp
 var manifest = new Manifest(new UrlWasmSource("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm"));
 
 using var plugin = new Plugin(manifest, new HostFunction[] { }, withWasi: true);
 ```
 
+F#:
+```fsharp
+let manifest = 
+    Manifest(new UrlWasmSource(Uri("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm")))
+
+use plugin = 
+    Plugin(manifest, Array.empty<HostFunction>(), withWasi = true)
+```
+
 > **Note**: The schema for this manifest can be found here: https://extism.org/docs/concepts/manifest/
 
+### Calling A Plug-in's Exports
 
-This plug-in was written in C and it does one thing, it counts vowels in a string. As such it exposes one "export" function: `count_vowels`. We can call exports using `Plugin.Call`:
+This plug-in was written in Rust and it does one thing, it counts vowels in a string. As such, it exposes one "export" function: `count_vowels`. We can call exports using `Plugin.Call`:
 
+C#:
 ```csharp
-var output = Encoding.UTF8.GetString(
-    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello, World!"))
-);
+var inputBytes = Encoding.UTF8.GetBytes("Hello, World!");
+var output = Encoding.UTF8.GetString(plugin.Call("count_vowels", inputBytes));
+
+// => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
+```
+
+F#:
+```fsharp
+let inputBytes = Encoding.UTF8.GetBytes("Hello, World!")
+let output = Encoding.UTF8.GetString(plugin.Call("count_vowels", inputBytes))
 
 // => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
 ```
@@ -61,6 +107,7 @@ All exports have a simple interface of optional bytes in, and optional bytes out
 
 Plug-ins may be stateful or stateless. Plug-ins can maintain state b/w calls by the use of variables. Our count vowels plug-in remembers the total number of vowels it's ever counted in the "total" key in the result. You can see this by making subsequent calls to the export:
 
+C#:
 ```csharp
 var output = Encoding.UTF8.GetString(
     plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello, World!"))
@@ -74,14 +121,26 @@ output = Encoding.UTF8.GetString(
 // => {"count": 3, "total": 9, "vowels": "aeiouAEIOU"}
 ```
 
+F#:
+```fsharp
+let inputBytes = Encoding.UTF8.GetBytes("Hello, World!")
+
+let output1 = Encoding.UTF8.GetString(plugin.Call("count_vowels", inputBytes))
+// => {"count": 3, "total": 6, "vowels": "aeiouAEIOU"}
+
+let output2 = Encoding.UTF8.GetString(plugin.Call("count_vowels", inputBytes))
+// => {"count": 3, "total": 9, "vowels": "aeiouAEIOU"}
+```
+
 These variables will persist until this plug-in is freed or you initialize a new one.
 
 ### Configuration
 
 Plug-ins may optionally take a configuration object. This is a static way to configure the plug-in. Our count-vowels plugin takes an optional configuration to change out which characters are considered vowels. Example:
 
+C#:
 ```csharp
-var manifest = new Manifest(new UrlWasmSource("https://raw.githubusercontent.com/extism/extism/main/wasm/code.wasm"));
+var manifest = new Manifest(new UrlWasmSource("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm"));
 
 using var plugin = new Plugin(manifest, new HostFunction[] { }, withWasi: true);
 
@@ -91,7 +150,7 @@ var output = Encoding.UTF8.GetString(
 
 // => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
 
-var manifest = new Manifest(new UrlWasmSource("https://raw.githubusercontent.com/extism/extism/main/wasm/count-vowels-host.wasm"))
+var manifest = new Manifest(new UrlWasmSource("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm"))
 {
     Config = new Dictionary<string, string>
     {
@@ -108,56 +167,127 @@ var output = Encoding.UTF8.GetString(
 // => {"count": 4, "total": 4, "vowels": "aeiouAEIOUY"}
 ```
 
+F#:
+```fsharp
+let manifest = Manifest(new UrlWasmSource(Uri("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm")))
+
+use plugin = Plugin(manifest, Array.empty<HostFunction>(), withWasi = true)
+
+let outputBytes = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Yellow, World!"))
+let output = Encoding.UTF8.GetString(outputBytes)
+
+let manifest = 
+    Manifest(new UrlWasmSource(Uri("https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm")),
+            Config = Dictionary<string, string>([("vowels", "aeiouyAEIOUY")]))
+
+use plugin = 
+    Plugin(manifest, Array.empty<HostFunction>(), withWasi = true)
+
+let outputBytes = 
+    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Yellow, World!"))
+let output = Encoding.UTF8.GetString(outputBytes)
+```
+
 ### Host Functions
 
-Host functions can be a complicated concept. You can think of them like custom syscalls for your plug-in. You can use them to add capabilities to your plug-in through a simple interface.
+Let's extend our count-vowels example a little bit: Instead of storing the `total` in an ephemeral plug-in var, let's store it in a persistent key-value store!
 
-Another way to look at it is this: Up until now we've only invoked functions given to us by our plug-in, but what if our plug-in needs to invoke a function in our .NET app? Host functions allow you to do this by passing a reference to a .NET method to the plug-in.
+Wasm can't use our KV store on it's own. This is where `Host Functions` come in.
 
-Let's load up a version of count vowels with a host function:
+[Host functions](https://extism.org/docs/concepts/host-functions) allow us to grant new capabilities to our plug-ins from our application. They are simply some Go functions you write which can be passed down and invoked from any language inside the plug-in.
 
+Let's load the manifest like usual but load up this `count_vowels_kvstore` plug-in:
+
+C#:
 ```csharp
-var manifest = new Manifest(new UrlWasmSource("https://raw.githubusercontent.com/extism/extism/main/wasm/count-vowels-host.wasm"));
+var manifest = new Manifest(new UrlWasmSource("https://github.com/extism/plugins/releases/latest/download/count_vowels_kvstore.wasm"));
 ```
 
-Unlike our original plug-in, this plug-in expects you to provide your own implementation of "is_vowel" in C#.
+F#:
+```fsharp
+let manifest = Manifest(new UrlWasmSource(Uri("https://github.com/extism/plugins/releases/latest/download/count_vowels_kvstore.wasm")))
+```
 
-First let's write our host function:
+> *Note*: The source code for this is [here](https://github.com/extism/plugins/blob/main/count_vowels_kvstore/src/lib.rs) and is written in rust, but it could be written in any of our PDK languages.
 
+Unlike our previous plug-in, this plug-in expects you to provide host functions that satisfy our its import interface for a KV store.
+
+We want to expose two functions to our plugin, `void kv_write(key string, value byte[])` which writes a bytes value to a key and `byte[] kv_read(key string)` which reads the bytes at the given `key`.
+
+C#:
 ```csharp
-void HelloWorld(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs, nint data)
+// pretend this is Redis or something :)
+var kvStore = new Dictionary<string, byte[]>();
+
+var functions = new[]
 {
-    Console.WriteLine("Hello from .NET!");
+    HostFunction.FromMethod("kv_read", "env", IntPtr.Zero, (CurrentPlugin plugin, long keyOffset) =>
+    {
+        var key = plugin.ReadString(keyOffset);
+        if (!kvStore.TryGetValue(key, out var value))
+        {
+            value = new byte[] { 0, 0, 0, 0 };
+        }
 
-    var letter = plugin.ReadString((nint)inputs[0].v.i64);
+        Console.WriteLine($"Read {BitConverter.ToUInt32(value)} from key={key}");
+        return plugin.WriteBytes(value);
+    }),
 
-    outputs[0].v.i64 = "aeiouAEIOU".Contains(letter) ? 1 : 0;
-}
+    HostFunction.FromMethod("kv_write", "env", IntPtr.Zero, (CurrentPlugin plugin, long keyOffset, long valueOffset) =>
+    {
+        var key = plugin.ReadString(keyOffset);
+        var value = plugin.ReadBytes(valueOffset);
+
+        Console.WriteLine($"Writing value={BitConverter.ToUInt32(value)} from key={key}");
+        kvStore[key] = value.ToArray();
+    })
+};
 ```
 
-This method will be exposed to the plug-in in it's native language. We need to know the inputs and outputs and their types ahead of time. This function expects a string (single character) as the first input and expects a 0 (false) or 1 (true) in the output (returns).
+F#:
+```
+```
+
+> *Note*: In order to write host functions you should get familiar with the methods on the CurrentPlugin type. The `plugin` parameter is an instance of this type.
 
 We need to pass these imports to the plug-in to create them. All imports of a plug-in must be satisfied for it to be initialized:
 
+C#:
 ```csharp
-// we need to give it the Wasm signature, it takes one i64 as input which acts as a pointer to a string
-// and it returns an i64 which is the 0 or 1 result
-using var helloWorld = new HostFunction(
-    "is_vowel",
-    "env",
-    new[] { ExtismValType.I64 },
-    new[] { ExtismValType.I64 },
-    null,
-    HelloWorld);
-
-using var plugin = new Plugin(manifest, new [] { helloWorld }, withWasi: true);
+using var plugin = new Plugin(manifest, functions, withWasi: true);
 
 var output = Encoding.UTF8.GetString(
-    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Yellow, World!"))
+    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World!"))
 );
 
-// => Hello From .NET!
-// => {"count": 3, "total": 3}
+Console.WriteLine($"Output: {output}");
+// => Read from key=count-vowels"
+// => Writing value=3 from key=count-vowels"
+// => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
+
+output = Encoding.UTF8.GetString(
+    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World!"))
+);
+
+Console.WriteLine($"Output: {output}");
+// => Read from key=count-vowels"
+// => Writing value=6 from key=count-vowels"
+// => {"count": 3, "total": 6, "vowels": "aeiouAEIOU"}
 ```
 
-Although this is a trivial example, you could imagine some more elaborate APIs for host functions. This is truly how you unleash the power of the plugin. You could, for example, imagine giving the plug-in access to APIs your app normally has like reading from a database, authenticating a user, sending messages, etc.
+F#:
+```fsharp
+use plugin = Plugin(manifest, functions, withWasi = true)
+
+let outputBytes = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World!"))
+printfn "Output: %s" Encoding.UTF8.GetString(outputBytes)
+// => Read from key=count-vowels
+// => Writing value=3 from key=count-vowels
+// => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
+
+let outputBytes2 = plugin.Call("count_vowels", inputBytes)
+printfn "Output: %s" Encoding.UTF8.GetString(outputBytes2)
+// => Read from key=count-vowels
+// => Writing value=6 from key=count-vowels
+// => {"count": 3, "total": 6, "vowels": "aeiouAEIOU"}
+```

--- a/samples/Extism.Sdk.Sample/Program.cs
+++ b/samples/Extism.Sdk.Sample/Program.cs
@@ -4,42 +4,39 @@ using Extism.Sdk.Native;
 using System.Runtime.InteropServices;
 using System.Text;
 
+var kvStore = new Dictionary<string, byte[]>();
+
 Console.WriteLine($"Version: {Plugin.ExtismVersion()}");
 
 var userData = Marshal.StringToHGlobalAnsi("Hello again!");
 
-using var helloWorld = new HostFunction(
-    "hello_world",
-    "env",
-    new[] { ExtismValType.I64 },
-    new[] { ExtismValType.I64 },
-    userData,
-    HelloWorld);
+var manifest = new Manifest(new UrlWasmSource("https://github.com/extism/plugins/releases/latest/download/count_vowels_kvstore.wasm"));
 
-void HelloWorld(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs, nint data)
+var functions = new[]
 {
-    Console.WriteLine("Hello from .NET!");
-
-    var text = Marshal.PtrToStringAnsi(data);
-    Console.WriteLine(text);
-
-    var input = plugin.ReadString(new nint(inputs[0].v.i64));
-    Console.WriteLine($"Input: {input}");
-
-    outputs[0].v.i64 = plugin.WriteString(input);
-}
-
-var manifest = new Manifest(new PathWasmSource("./code-functions.wasm"))
-{
-    Config = new Dictionary<string, string>
+    HostFunction.FromMethod("kv_read", "env", IntPtr.Zero, (CurrentPlugin plugin, long keyOffset) =>
     {
-        { "my-key", "some cool value" }
-    },
+        var key = plugin.ReadString(keyOffset);
+        if (!kvStore.TryGetValue(key, out var value))
+        {
+            value = new byte[] { 0, 0, 0, 0 };
+        }
+
+        Console.WriteLine($"Read {BitConverter.ToUInt32(value)} from key={key}");
+        return plugin.WriteBytes(value);
+    }),
+
+    HostFunction.FromMethod("kv_write", "env", IntPtr.Zero, (CurrentPlugin plugin, long keyOffset, long valueOffset) =>
+    {
+        var key = plugin.ReadString(keyOffset);
+        var value = plugin.ReadBytes(valueOffset);
+
+        Console.WriteLine($"Writing value={BitConverter.ToUInt32(value)} from key={key}");
+        kvStore[key] = value.ToArray();
+    })
 };
 
-using var plugin = new Plugin(manifest, new[] { helloWorld }, withWasi: true);
-
-Console.WriteLine("Plugin creatd!!!");
+using var plugin = new Plugin(manifest, functions, withWasi: true);
 
 var output = Encoding.UTF8.GetString(
     plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World!"))
@@ -47,3 +44,8 @@ var output = Encoding.UTF8.GetString(
 
 Console.WriteLine($"Output: {output}");
 
+output = Encoding.UTF8.GetString(
+    plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World!"))
+);
+
+Console.WriteLine($"Output: {output}");

--- a/src/Extism.Sdk/HostFunction.cs
+++ b/src/Extism.Sdk/HostFunction.cs
@@ -2,6 +2,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+using static Extism.Sdk.Native.LibExtism;
+
 namespace Extism.Sdk
 {
     /// <summary>
@@ -10,8 +12,7 @@ namespace Extism.Sdk
     /// <param name="plugin">Plugin Index</param>
     /// <param name="inputs">Input parameters</param>
     /// <param name="outputs">Output parameters, the host function can change this.</param>
-    /// <param name="userData">A data passed in during Host Function creation.</param>
-    public delegate void ExtismFunction(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs, IntPtr userData);
+    public delegate void ExtismFunction(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs);
 
     /// <summary>
     /// A function provided by the host that plugins can call.
@@ -21,7 +22,7 @@ namespace Extism.Sdk
         private const int DisposedMarker = 1;
         private int _disposed;
         private readonly ExtismFunction _function;
-        private readonly LibExtism.InternalExtismFunction _callback;
+        private readonly InternalExtismFunction _callback;
 
         /// <summary>
         /// Registers a Host Function.
@@ -29,14 +30,14 @@ namespace Extism.Sdk
         /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
         /// <param name="inputTypes">The types of the input arguments/parameters the <see cref="Plugin"/> caller will provide.</param>
         /// <param name="outputTypes">The types of the output returned from the host function to the <see cref="Plugin"/>.</param>
-        /// <param name="userData">An opaque pointer to an object from the host, accessible to the <see cref="Plugin"/>.
+        /// <param name="userData">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
         /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
         /// <param name="hostFunction"></param>
         public HostFunction(
             string functionName,
             Span<ExtismValType> inputTypes,
             Span<ExtismValType> outputTypes,
-            IntPtr userData,
+            nint userData,
             ExtismFunction hostFunction) :
             this(functionName, "", inputTypes, outputTypes, userData, hostFunction)
         {
@@ -50,7 +51,7 @@ namespace Extism.Sdk
         /// <param name="namespace">Function namespace.</param>
         /// <param name="inputTypes">The types of the input arguments/parameters the <see cref="Plugin"/> caller will provide.</param>
         /// <param name="outputTypes">The types of the output returned from the host function to the <see cref="Plugin"/>.</param>
-        /// <param name="userData">An opaque pointer to an object from the host, accessible to the <see cref="Plugin"/>.
+        /// <param name="userData">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
         /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
         /// <param name="hostFunction"></param>
         unsafe public HostFunction(
@@ -58,7 +59,7 @@ namespace Extism.Sdk
             string @namespace,
             Span<ExtismValType> inputTypes,
             Span<ExtismValType> outputTypes,
-            IntPtr userData,
+            nint userData,
             ExtismFunction hostFunction)
         {
             // Make sure we store the delegate referene in a field so that it doesn't get garbage collected
@@ -68,30 +69,336 @@ namespace Extism.Sdk
             fixed (ExtismValType* inputs = inputTypes)
             fixed (ExtismValType* outputs = outputTypes)
             {
-                NativeHandle = LibExtism.extism_function_new(functionName, inputs, inputTypes.Length, outputs, outputTypes.Length, _callback, userData, IntPtr.Zero);
+                NativeHandle = extism_function_new(functionName, inputs, inputTypes.Length, outputs, outputTypes.Length, _callback, userData, IntPtr.Zero);
             }
 
             if (!string.IsNullOrEmpty(@namespace))
             {
-                LibExtism.extism_function_set_namespace(NativeHandle, @namespace);
+                extism_function_set_namespace(NativeHandle, @namespace);
             }
         }
 
+        internal nint NativeHandle { get; }
+
         private unsafe void CallbackImpl(
-            nint plugin,
+            long plugin,
             ExtismVal* inputsPtr,
             uint n_inputs,
             ExtismVal* outputsPtr,
             uint n_outputs,
-            IntPtr data)
+            nint data)
         {
             var outputs = new Span<ExtismVal>(outputsPtr, (int)n_outputs);
             var inputs = new Span<ExtismVal>(inputsPtr, (int)n_inputs);
 
-            _function(new CurrentPlugin(plugin), inputs, outputs, data);
+            _function(new CurrentPlugin(plugin, data), inputs, outputs);
         }
 
-        internal IntPtr NativeHandle { get; }
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns no values.
+        /// </summary>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Action<CurrentPlugin> callback)
+        {
+            var inputTypes = new ExtismValType[] { };
+            var returnType = new ExtismValType[] { };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    callback(plugin);
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns no values. Supported parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Action<CurrentPlugin, I1> callback)
+            where I1 : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
+            var returnType = new ExtismValType[] { };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    callback(plugin, GetValue<I1>(inputs[0]));
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameters an returns no values. Supported parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1, I2>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Action<CurrentPlugin, I1, I2> callback)
+            where I1 : struct
+            where I2 : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
+
+            var returnType = new ExtismValType[] { };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameters an returns no values. Supported parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1, I2, I3>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Action<CurrentPlugin, I1, I2, I3> callback)
+            where I1 : struct
+            where I2 : struct
+            where I3 : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
+            var returnType = new ExtismValType[] { };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns a value. Supported return types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<R>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Func<CurrentPlugin, R> callback)
+            where R : struct
+        {
+            var inputTypes = new ExtismValType[] { };
+            var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    var value = callback(plugin);
+                    SetValue(ref outputs[0], value);
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns a value. Supported return and parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1, R>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Func<CurrentPlugin, I1, R> callback)
+            where I1 : struct
+            where R : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
+            var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    var value = callback(plugin, GetValue<I1>(inputs[0]));
+                    SetValue(ref outputs[0], value);
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameter an returns a value. Supported return and parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1, I2, R>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Func<CurrentPlugin, I1, I2, R> callback)
+            where I1 : struct
+            where I2 : struct
+            where R : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
+            var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
+                    SetValue(ref outputs[0], value);
+                });
+        }
+
+        /// <summary>
+        /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameter an returns a value. Supported return and parameter types:
+        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+        /// </summary>
+        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+        /// <param name="namespace">Function namespace. Usually `env`.</param>
+        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+        /// <param name="callback">The host function implementation.</param>
+        /// <returns></returns>
+        public static HostFunction FromMethod<I1, I2, I3, R>(
+            string functionName,
+            string @namespace,
+            nint userdata,
+            Func<CurrentPlugin, I1, I2, I3, R> callback)
+            where I1 : struct
+            where I2 : struct
+            where I3 : struct
+            where R : struct
+        {
+            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
+            var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+            return new HostFunction(functionName, @namespace, inputTypes, returnType, userdata,
+                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+                {
+                    var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
+                    SetValue(ref outputs[0], value);
+                });
+        }
+
+        private static ExtismValType ToExtismType<T>() where T : struct
+        {
+            return typeof(T) switch
+            {
+                Type t when t == typeof(int) || t == typeof(uint) => ExtismValType.I32,
+                Type t when t == typeof(long) || t == typeof(ulong) => ExtismValType.I64,
+                Type t when t == typeof(float) => ExtismValType.F32,
+                Type t when t == typeof(double) => ExtismValType.F64,
+                _ => throw new NotImplementedException($"Unsupported type: {typeof(T).Name}"),
+            };
+        }
+
+        private static T GetValue<T>(ExtismVal val) where T : struct
+        {
+            return typeof(T) switch
+            {
+                Type intType when intType == typeof(int) && val.t == ExtismValType.I32 => (T)(object)val.v.i32,
+                Type longType when longType == typeof(long) && val.t == ExtismValType.I64 => (T)(object)val.v.i64,
+                Type floatType when floatType == typeof(float) && val.t == ExtismValType.F32 => (T)(object)val.v.f32,
+                Type doubleType when doubleType == typeof(double) && val.t == ExtismValType.F64 => (T)(object)val.v.f64,
+                _ => throw new InvalidOperationException($"Unsupported conversion from {Enum.GetName(typeof(ExtismValType), val.t)} to {typeof(T).Name}")
+            };
+        }
+
+        private static void SetValue<T>(ref ExtismVal val, T t)
+        {
+            if (t is int i32)
+            {
+                val.t = ExtismValType.I32;
+                val.v.i32 = i32;
+            }
+            else if (t is uint u32)
+            {
+                val.t = ExtismValType.I32;
+                val.v.i32 = (int)u32;
+            }
+            else if (t is long i64)
+            {
+                val.t = ExtismValType.I64;
+                val.v.i64 = i64;
+            }
+            else if (t is ulong u64)
+            {
+                val.t = ExtismValType.I64;
+                val.v.i64 = (long)u64;
+            }
+            else if (t is float f32)
+            {
+                val.t = ExtismValType.F32;
+                val.v.f32 = f32;
+            }
+            else if (t is double f64)
+            {
+                val.t = ExtismValType.F64;
+                val.v.f64 = f64;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported value type: {typeof(T).Name}");
+            }
+        }
 
         /// <summary>
         /// Frees all resources held by this Host Function.
@@ -138,7 +445,7 @@ namespace Extism.Sdk
             }
 
             // Free up unmanaged resources
-            LibExtism.extism_function_free(NativeHandle);
+            extism_function_free(NativeHandle);
         }
 
         /// <summary>

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -44,7 +44,7 @@ public enum ExtismValType : int
     I32,
 
     /// <summary>
-    /// Signed 64 bit integer. Equivalent of <see cref="long"/> or <see cref="ulong"/>
+    /// Signed 64 bit integer. Equivalent of <see cref="long"/> or <see cref="long"/>
     /// </summary>
     I64,
 
@@ -111,7 +111,7 @@ internal static class LibExtism
     /// <param name="outputs"></param>
     /// <param name="n_outputs"></param>
     /// <param name="data"></param>
-    unsafe internal delegate void InternalExtismFunction(nint plugin, ExtismVal* inputs, uint n_inputs, ExtismVal* outputs, uint n_outputs, IntPtr data);
+    unsafe internal delegate void InternalExtismFunction(long plugin, ExtismVal* inputs, uint n_inputs, ExtismVal* outputs, uint n_outputs, IntPtr data);
 
     /// <summary>
     /// Returns a pointer to the memory of the currently running plugin.
@@ -120,7 +120,7 @@ internal static class LibExtism
     /// <param name="plugin"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory")]
-    internal static extern IntPtr extism_current_plugin_memory(nint plugin);
+    internal static extern long extism_current_plugin_memory(long plugin);
 
     /// <summary>
     /// Allocate a memory block in the currently running plugin
@@ -129,7 +129,7 @@ internal static class LibExtism
     /// <param name="n"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_alloc")]
-    internal static extern IntPtr extism_current_plugin_memory_alloc(nint plugin, long n);
+    internal static extern long extism_current_plugin_memory_alloc(long plugin, long n);
 
     /// <summary>
     /// Get the length of an allocated block.
@@ -139,7 +139,7 @@ internal static class LibExtism
     /// <param name="n"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_length")]
-    internal static extern long extism_current_plugin_memory_length(nint plugin, long n);
+    internal static extern long extism_current_plugin_memory_length(long plugin, long n);
 
     /// <summary>
     /// Get the length of an allocated block.
@@ -148,7 +148,7 @@ internal static class LibExtism
     /// <param name="plugin"></param>
     /// <param name="ptr"></param>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_free")]
-    internal static extern void extism_current_plugin_memory_free(nint plugin, IntPtr ptr);
+    internal static extern void extism_current_plugin_memory_free(long plugin, long ptr);
 
     /// <summary>
     /// Create a new host function.
@@ -191,7 +191,7 @@ internal static class LibExtism
     /// <param name="errmsg"></param>
     /// <returns></returns>
     [DllImport("extism")]
-    unsafe internal static extern ExtismPlugin* extism_plugin_new(byte* wasm, ulong wasmSize, IntPtr* functions, ulong nFunctions, [MarshalAs(UnmanagedType.I1)] bool withWasi, out char** errmsg);
+    unsafe internal static extern ExtismPlugin* extism_plugin_new(byte* wasm, long wasmSize, IntPtr* functions, long nFunctions, [MarshalAs(UnmanagedType.I1)] bool withWasi, out char** errmsg);
 
     /// <summary>
     /// Frees a plugin error message.

--- a/src/Extism.Sdk/Plugin.cs
+++ b/src/Extism.Sdk/Plugin.cs
@@ -78,7 +78,7 @@ public unsafe class Plugin : IDisposable
     {
         char** errorMsgPtr;
 
-        var handle = LibExtism.extism_plugin_new(wasmPtr, (ulong)wasmLength, functionsPtr, (ulong)functions.Length, withWasi, out errorMsgPtr);
+        var handle = LibExtism.extism_plugin_new(wasmPtr, wasmLength, functionsPtr, functions.Length, withWasi, out errorMsgPtr);
         if (handle == null)
         {
             var msg = "Unable to create plugin";


### PR DESCRIPTION
 - update readme to be similar to ruby sdk
 - add a convenience layer for host functions
 - used `long`s for memory offsets intead of `nint`
 - renamed `pointer` to `offset` when talking about memory in the code comments and parameter names