### PR TITLE
feat: Use native nuget packages

### DIFF
--- a/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
+++ b/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
@@ -10,6 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.0.0-rc0" />
 		<ProjectReference Include="..\..\src\Extism.Sdk\Extism.Sdk.csproj" />
 	</ItemGroup>
 

--- a/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
+++ b/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!--<PackageReference Include="Extism.runtime.win-x64" Version="0.4.0" />-->
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.0.0-rc0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Extism.Sdk/Extism.Sdk.csproj
+++ b/src/Extism.Sdk/Extism.Sdk.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-	  <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Extism.Sdk/Extism.Sdk.csproj
+++ b/src/Extism.Sdk/Extism.Sdk.csproj
@@ -18,6 +18,12 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/Extism.Sdk/Extism.Sdk.csproj
+++ b/src/Extism.Sdk/Extism.Sdk.csproj
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	  <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/test/Extism.Sdk/Extism.Sdk.Tests.csproj
+++ b/test/Extism.Sdk/Extism.Sdk.Tests.csproj
@@ -8,10 +8,6 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Extism.runtime.all" Version="1.0.0-rc0" Condition="'$(GITHUB_ACTIONS)' == 'false'" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />

--- a/test/Extism.Sdk/Extism.Sdk.Tests.csproj
+++ b/test/Extism.Sdk/Extism.Sdk.Tests.csproj
@@ -8,7 +8,12 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+
 	<ItemGroup>
+		<PackageReference Include="Extism.runtime.all" Version="1.0.0-rc0" Condition="'$(GITHUB_ACTIONS)' == 'false'" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 		<PackageReference Include="Shouldly" Version="4.2.1" />
 		<PackageReference Include="xunit" Version="2.5.1" />


### PR DESCRIPTION
- Use native nuget packages in the samples and in the tests (unless it's in CI)
- Publish symbols with the package
- Focus on the native nuget packages in the readme as that's the most ntaural experience for .NET devs
- Set [ContiniousIntegrationBuild](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild) when in CI