### PR TITLE
refactor: place normal C# classes in Extism.Sdk namespace

### DIFF
--- a/samples/Extism.Sdk.FSharpSample/Program.fs
+++ b/samples/Extism.Sdk.FSharpSample/Program.fs
@@ -1,5 +1,4 @@
 ﻿open Extism.Sdk
-open Extism.Sdk.Native
 open System
 open System.Text
 open System.Collections.Generic

--- a/samples/Extism.Sdk.Sample/Program.cs
+++ b/samples/Extism.Sdk.Sample/Program.cs
@@ -1,5 +1,4 @@
 using Extism.Sdk;
-using Extism.Sdk.Native;
 
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -1,156 +1,153 @@
-﻿using Extism.Sdk.Native;
+﻿using System.Text;
+using Extism.Sdk.Native;
 
-using System.Text;
-
-namespace Extism.Sdk
+namespace Extism.Sdk;
+/// <summary>
+/// Represents the current plugin. Can only be used within <see cref="HostFunction"/>s.
+/// </summary>
+public class CurrentPlugin
 {
-    /// <summary>
-    /// Represents the current plugin. Can only be used within <see cref="HostFunction"/>s.
-    /// </summary>
-    public class CurrentPlugin
+    internal CurrentPlugin(long nativeHandle, nint userData)
     {
-        internal CurrentPlugin(long nativeHandle, nint userData)
+        NativeHandle = nativeHandle;
+        UserData = userData;
+    }
+
+    internal long NativeHandle { get; }
+
+    /// <summary>
+    /// An opaque pointer to an object from the host, passed in when a <see cref="HostFunction"/> is registered.
+    /// </summary>
+    public nint UserData { get; set; }
+
+    /// <summary>
+    /// Returns a offset to the memory of the currently running plugin.
+    /// NOTE: this should only be called from host functions.
+    /// </summary>
+    /// <returns></returns>
+    public long GetMemory()
+    {
+        return LibExtism.extism_current_plugin_memory(NativeHandle);
+    }
+
+    /// <summary>
+    /// Reads a string from a memory block using UTF8.
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    public string ReadString(long offset)
+    {
+        return ReadString(offset, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Reads a string form a memory block.
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <param name="encoding"></param>
+    /// <returns></returns>
+    public string ReadString(long offset, Encoding encoding)
+    {
+        var buffer = ReadBytes(offset);
+
+        return encoding.GetString(buffer);
+    }
+
+    /// <summary>
+    /// Returns a span of bytes for a given block.
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    public unsafe Span<byte> ReadBytes(long offset)
+    {
+        var mem = GetMemory();
+        var length = (int)BlockLength(offset);
+        var ptr = (byte*)mem + offset;
+
+        return new Span<byte>(ptr, length);
+    }
+
+    /// <summary>
+    /// Writes a string into the current plugin memory using UTF-8 encoding and returns the offset of the block.
+    /// </summary>
+    /// <param name="value"></param>
+    public long WriteString(string value)
+        => WriteString(value, Encoding.UTF8);
+
+    /// <summary>
+    /// Writes a string into the current plugin memory and returns the offset of the block.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="encoding"></param>
+    public long WriteString(string value, Encoding encoding)
+    {
+        var bytes = encoding.GetBytes(value);
+        var offset = AllocateBlock(bytes.Length);
+        WriteBytes(offset, bytes);
+
+        return offset;
+    }
+
+    /// <summary>
+    /// Writes a byte array into a newly allocated block of memory.
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns>Returns the offset of the allocated block</returns>
+    public long WriteBytes(Span<byte> bytes)
+    {
+        var offset = AllocateBlock(bytes.Length);
+        WriteBytes(offset, bytes);
+        return offset;
+    }
+
+    /// <summary>
+    /// Writes a byte array into a block of memory.
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <param name="bytes"></param>
+    public unsafe void WriteBytes(long offset, Span<byte> bytes)
+    {
+        var length = BlockLength(offset);
+        if (length < bytes.Length)
         {
-            NativeHandle = nativeHandle;
-            UserData = userData;
+            throw new InvalidOperationException("Destination block length is less than source block length.");
         }
 
-        internal long NativeHandle { get; }
+        var mem = GetMemory();
+        var ptr = (void*)(mem + offset);
+        var destination = new Span<byte>(ptr, bytes.Length);
 
-        /// <summary>
-        /// An opaque pointer to an object from the host, passed in when a <see cref="HostFunction"/> is registered.
-        /// </summary>
-        public nint UserData { get; set; }
+        bytes.CopyTo(destination);
+    }
 
-        /// <summary>
-        /// Returns a offset to the memory of the currently running plugin.
-        /// NOTE: this should only be called from host functions.
-        /// </summary>
-        /// <returns></returns>
-        public long GetMemory()
-        {
-            return LibExtism.extism_current_plugin_memory(NativeHandle);
-        }
+    /// <summary>
+    /// Frees a block of memory belonging to the current plugin.
+    /// </summary>
+    /// <param name="offset"></param>
+    public void FreeBlock(long offset)
+    {
+        LibExtism.extism_current_plugin_memory_free(NativeHandle, offset);
+    }
 
-        /// <summary>
-        /// Reads a string from a memory block using UTF8.
-        /// </summary>
-        /// <param name="offset"></param>
-        /// <returns></returns>
-        public string ReadString(long offset)
-        {
-            return ReadString(offset, Encoding.UTF8);
-        }
+    /// <summary>
+    /// Allocate a memory block in the currently running plugin.
+    /// 
+    /// </summary>
+    /// <param name="length"></param>
+    /// <returns></returns>
+    public long AllocateBlock(long length)
+    {
+        return LibExtism.extism_current_plugin_memory_alloc(NativeHandle, length);
+    }
 
-        /// <summary>
-        /// Reads a string form a memory block.
-        /// </summary>
-        /// <param name="offset"></param>
-        /// <param name="encoding"></param>
-        /// <returns></returns>
-        public string ReadString(long offset, Encoding encoding)
-        {
-            var buffer = ReadBytes(offset);
-
-            return encoding.GetString(buffer);
-        }
-
-        /// <summary>
-        /// Returns a span of bytes for a given block.
-        /// </summary>
-        /// <param name="offset"></param>
-        /// <returns></returns>
-        public unsafe Span<byte> ReadBytes(long offset)
-        {
-            var mem = GetMemory();
-            var length = (int)BlockLength(offset);
-            var ptr = (byte*)mem + offset;
-
-            return new Span<byte>(ptr, length);
-        }
-
-        /// <summary>
-        /// Writes a string into the current plugin memory using UTF-8 encoding and returns the offset of the block.
-        /// </summary>
-        /// <param name="value"></param>
-        public long WriteString(string value)
-            => WriteString(value, Encoding.UTF8);
-
-        /// <summary>
-        /// Writes a string into the current plugin memory and returns the offset of the block.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <param name="encoding"></param>
-        public long WriteString(string value, Encoding encoding)
-        {
-            var bytes = encoding.GetBytes(value);
-            var offset = AllocateBlock(bytes.Length);
-            WriteBytes(offset, bytes);
-
-            return offset;
-        }
-
-        /// <summary>
-        /// Writes a byte array into a newly allocated block of memory.
-        /// </summary>
-        /// <param name="bytes"></param>
-        /// <returns>Returns the offset of the allocated block</returns>
-        public long WriteBytes(Span<byte> bytes)
-        {
-            var offset = AllocateBlock(bytes.Length);
-            WriteBytes(offset, bytes);
-            return offset;
-        }
-
-        /// <summary>
-        /// Writes a byte array into a block of memory.
-        /// </summary>
-        /// <param name="offset"></param>
-        /// <param name="bytes"></param>
-        public unsafe void WriteBytes(long offset, Span<byte> bytes)
-        {
-            var length = BlockLength(offset);
-            if (length < bytes.Length)
-            {
-                throw new InvalidOperationException("Destination block length is less than source block length.");
-            }
-
-            var mem = GetMemory();
-            var ptr = (void*)(mem + offset);
-            var destination = new Span<byte>(ptr, bytes.Length);
-
-            bytes.CopyTo(destination);
-        }
-
-        /// <summary>
-        /// Frees a block of memory belonging to the current plugin.
-        /// </summary>
-        /// <param name="offset"></param>
-        public void FreeBlock(long offset)
-        {
-            LibExtism.extism_current_plugin_memory_free(NativeHandle, offset);
-        }
-
-        /// <summary>
-        /// Allocate a memory block in the currently running plugin.
-        /// 
-        /// </summary>
-        /// <param name="length"></param>
-        /// <returns></returns>
-        public long AllocateBlock(long length)
-        {
-            return LibExtism.extism_current_plugin_memory_alloc(NativeHandle, length);
-        }
-
-        /// <summary>
-        /// Get the length of an allocated block.
-        /// NOTE: this should only be called from host functions.
-        /// </summary>
-        /// <param name="offset"></param>
-        /// <returns></returns>
-        public long BlockLength(long offset)
-        {
-            return LibExtism.extism_current_plugin_memory_length(NativeHandle, offset);
-        }
+    /// <summary>
+    /// Get the length of an allocated block.
+    /// NOTE: this should only be called from host functions.
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    public long BlockLength(long offset)
+    {
+        return LibExtism.extism_current_plugin_memory_length(NativeHandle, offset);
     }
 }

--- a/src/Extism.Sdk/ExtismException.cs
+++ b/src/Extism.Sdk/ExtismException.cs
@@ -1,4 +1,4 @@
-namespace Extism.Sdk.Native;
+namespace Extism.Sdk;
 
 using System;
 

--- a/src/Extism.Sdk/HostFunction.cs
+++ b/src/Extism.Sdk/HostFunction.cs
@@ -1,428 +1,424 @@
 ﻿using Extism.Sdk.Native;
-
 using System.Diagnostics.CodeAnalysis;
 
-using static Extism.Sdk.Native.LibExtism;
+namespace Extism.Sdk;
 
-namespace Extism.Sdk
+/// <summary>
+/// A host function signature.
+/// </summary>
+/// <param name="plugin">Plugin Index</param>
+/// <param name="inputs">Input parameters</param>
+/// <param name="outputs">Output parameters, the host function can change this.</param>
+public delegate void ExtismFunction(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs);
+
+/// <summary>
+/// A function provided by the host that plugins can call.
+/// </summary>
+public class HostFunction : IDisposable
 {
-    /// <summary>
-    /// A host function signature.
-    /// </summary>
-    /// <param name="plugin">Plugin Index</param>
-    /// <param name="inputs">Input parameters</param>
-    /// <param name="outputs">Output parameters, the host function can change this.</param>
-    public delegate void ExtismFunction(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs);
+    private const int DisposedMarker = 1;
+    private int _disposed;
+    private readonly ExtismFunction _function;
+    private readonly LibExtism.InternalExtismFunction _callback;
 
     /// <summary>
-    /// A function provided by the host that plugins can call.
+    /// Registers a Host Function.
     /// </summary>
-    public class HostFunction : IDisposable
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="inputTypes">The types of the input arguments/parameters the <see cref="Plugin"/> caller will provide.</param>
+    /// <param name="outputTypes">The types of the output returned from the host function to the <see cref="Plugin"/>.</param>
+    /// <param name="userData">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="hostFunction"></param>
+    unsafe public HostFunction(
+        string functionName,
+        Span<ExtismValType> inputTypes,
+        Span<ExtismValType> outputTypes,
+        nint userData,
+        ExtismFunction hostFunction)
     {
-        private const int DisposedMarker = 1;
-        private int _disposed;
-        private readonly ExtismFunction _function;
-        private readonly InternalExtismFunction _callback;
+        // Make sure we store the delegate referene in a field so that it doesn't get garbage collected
+        _function = hostFunction;
+        _callback = CallbackImpl;
 
-        /// <summary>
-        /// Registers a Host Function.
-        /// </summary>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="inputTypes">The types of the input arguments/parameters the <see cref="Plugin"/> caller will provide.</param>
-        /// <param name="outputTypes">The types of the output returned from the host function to the <see cref="Plugin"/>.</param>
-        /// <param name="userData">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="hostFunction"></param>
-        unsafe public HostFunction(
-            string functionName,
-            Span<ExtismValType> inputTypes,
-            Span<ExtismValType> outputTypes,
-            nint userData,
-            ExtismFunction hostFunction)
+        fixed (ExtismValType* inputs = inputTypes)
+        fixed (ExtismValType* outputs = outputTypes)
         {
-            // Make sure we store the delegate referene in a field so that it doesn't get garbage collected
-            _function = hostFunction;
-            _callback = CallbackImpl;
+            NativeHandle = LibExtism.extism_function_new(functionName, inputs, inputTypes.Length, outputs, outputTypes.Length, _callback, userData, IntPtr.Zero);
+        }
+    }
 
-            fixed (ExtismValType* inputs = inputTypes)
-            fixed (ExtismValType* outputs = outputTypes)
+    internal nint NativeHandle { get; }
+
+    /// <summary>
+    /// Sets the function namespace. By default it's set to `env`.
+    /// </summary>
+    /// <param name="ns"></param>
+    public void SetNamespace(string ns)
+    {
+        if (!string.IsNullOrEmpty(ns))
+        {
+            LibExtism.extism_function_set_namespace(NativeHandle, ns);
+        }
+    }
+
+    private unsafe void CallbackImpl(
+        long plugin,
+        ExtismVal* inputsPtr,
+        uint n_inputs,
+        ExtismVal* outputsPtr,
+        uint n_outputs,
+        nint data)
+    {
+        var outputs = new Span<ExtismVal>(outputsPtr, (int)n_outputs);
+        var inputs = new Span<ExtismVal>(inputsPtr, (int)n_inputs);
+
+        _function(new CurrentPlugin(plugin, data), inputs, outputs);
+    }
+
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns no values.
+    /// </summary>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod(
+        string functionName,
+        nint userdata,
+        Action<CurrentPlugin> callback)
+    {
+        var inputTypes = new ExtismValType[] { };
+        var returnType = new ExtismValType[] { };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
-                NativeHandle = extism_function_new(functionName, inputs, inputTypes.Length, outputs, outputTypes.Length, _callback, userData, IntPtr.Zero);
-            }
-        }
+                callback(plugin);
+            });
+    }
 
-        internal nint NativeHandle { get; }
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns no values. Supported parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1>(
+        string functionName,
+        nint userdata,
+        Action<CurrentPlugin, I1> callback)
+        where I1 : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
+        var returnType = new ExtismValType[] { };
 
-        /// <summary>
-        /// Sets the function namespace. By default it's set to `env`.
-        /// </summary>
-        /// <param name="ns"></param>
-        public void SetNamespace(string ns)
-        {
-            if (!string.IsNullOrEmpty(ns))
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
-                extism_function_set_namespace(NativeHandle, ns);
-            }
-        }
+                callback(plugin, GetValue<I1>(inputs[0]));
+            });
+    }
 
-        private unsafe void CallbackImpl(
-            long plugin,
-            ExtismVal* inputsPtr,
-            uint n_inputs,
-            ExtismVal* outputsPtr,
-            uint n_outputs,
-            nint data)
-        {
-            var outputs = new Span<ExtismVal>(outputsPtr, (int)n_outputs);
-            var inputs = new Span<ExtismVal>(inputsPtr, (int)n_inputs);
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameters an returns no values. Supported parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, I2>(
+        string functionName,
+        nint userdata,
+        Action<CurrentPlugin, I1, I2> callback)
+        where I1 : struct
+        where I2 : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
 
-            _function(new CurrentPlugin(plugin, data), inputs, outputs);
-        }
+        var returnType = new ExtismValType[] { };
 
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns no values.
-        /// </summary>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod(
-            string functionName,
-            nint userdata,
-            Action<CurrentPlugin> callback)
-        {
-            var inputTypes = new ExtismValType[] { };
-            var returnType = new ExtismValType[] { };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    callback(plugin);
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns no values. Supported parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1>(
-            string functionName,
-            nint userdata,
-            Action<CurrentPlugin, I1> callback)
-            where I1 : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
-            var returnType = new ExtismValType[] { };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    callback(plugin, GetValue<I1>(inputs[0]));
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameters an returns no values. Supported parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, I2>(
-            string functionName,
-            nint userdata,
-            Action<CurrentPlugin, I1, I2> callback)
-            where I1 : struct
-            where I2 : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
-
-            var returnType = new ExtismValType[] { };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameters an returns no values. Supported parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, I2, I3>(
-            string functionName,
-            nint userdata,
-            Action<CurrentPlugin, I1, I2, I3> callback)
-            where I1 : struct
-            where I2 : struct
-            where I3 : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
-            var returnType = new ExtismValType[] { };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns a value. Supported return types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<R>(
-            string functionName,
-            nint userdata,
-            Func<CurrentPlugin, R> callback)
-            where R : struct
-        {
-            var inputTypes = new ExtismValType[] { };
-            var returnType = new ExtismValType[] { ToExtismType<R>() };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    var value = callback(plugin);
-                    SetValue(ref outputs[0], value);
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns a value. Supported return and parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, R>(
-            string functionName,
-            nint userdata,
-            Func<CurrentPlugin, I1, R> callback)
-            where I1 : struct
-            where R : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
-            var returnType = new ExtismValType[] { ToExtismType<R>() };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    var value = callback(plugin, GetValue<I1>(inputs[0]));
-                    SetValue(ref outputs[0], value);
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameter an returns a value. Supported return and parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, I2, R>(
-            string functionName,
-            nint userdata,
-            Func<CurrentPlugin, I1, I2, R> callback)
-            where I1 : struct
-            where I2 : struct
-            where R : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
-            var returnType = new ExtismValType[] { ToExtismType<R>() };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
-                    SetValue(ref outputs[0], value);
-                });
-        }
-
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameter an returns a value. Supported return and parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, I2, I3, R>(
-            string functionName,
-            nint userdata,
-            Func<CurrentPlugin, I1, I2, I3, R> callback)
-            where I1 : struct
-            where I2 : struct
-            where I3 : struct
-            where R : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
-            var returnType = new ExtismValType[] { ToExtismType<R>() };
-
-            return new HostFunction(functionName, inputTypes, returnType, userdata,
-                (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
-                {
-                    var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
-                    SetValue(ref outputs[0], value);
-                });
-        }
-
-        private static ExtismValType ToExtismType<T>() where T : struct
-        {
-            return typeof(T) switch
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
-                Type t when t == typeof(int) || t == typeof(uint) => ExtismValType.I32,
-                Type t when t == typeof(long) || t == typeof(ulong) => ExtismValType.I64,
-                Type t when t == typeof(float) => ExtismValType.F32,
-                Type t when t == typeof(double) => ExtismValType.F64,
-                _ => throw new NotImplementedException($"Unsupported type: {typeof(T).Name}"),
-            };
-        }
+                callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
+            });
+    }
 
-        private static T GetValue<T>(ExtismVal val) where T : struct
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameters an returns no values. Supported parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, I2, I3>(
+        string functionName,
+        nint userdata,
+        Action<CurrentPlugin, I1, I2, I3> callback)
+        where I1 : struct
+        where I2 : struct
+        where I3 : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
+        var returnType = new ExtismValType[] { };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+            {
+                callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
+            });
+    }
+
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns a value. Supported return types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<R>(
+        string functionName,
+        nint userdata,
+        Func<CurrentPlugin, R> callback)
+        where R : struct
+    {
+        var inputTypes = new ExtismValType[] { };
+        var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+            {
+                var value = callback(plugin);
+                SetValue(ref outputs[0], value);
+            });
+    }
+
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 1 parameter an returns a value. Supported return and parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, R>(
+        string functionName,
+        nint userdata,
+        Func<CurrentPlugin, I1, R> callback)
+        where I1 : struct
+        where R : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
+        var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+            {
+                var value = callback(plugin, GetValue<I1>(inputs[0]));
+                SetValue(ref outputs[0], value);
+            });
+    }
+
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 2 parameter an returns a value. Supported return and parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, I2, R>(
+        string functionName,
+        nint userdata,
+        Func<CurrentPlugin, I1, I2, R> callback)
+        where I1 : struct
+        where I2 : struct
+        where R : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
+        var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+            {
+                var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
+                SetValue(ref outputs[0], value);
+            });
+    }
+
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameter an returns a value. Supported return and parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, I2, I3, R>(
+        string functionName,
+        nint userdata,
+        Func<CurrentPlugin, I1, I2, I3, R> callback)
+        where I1 : struct
+        where I2 : struct
+        where I3 : struct
+        where R : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
+        var returnType = new ExtismValType[] { ToExtismType<R>() };
+
+        return new HostFunction(functionName, inputTypes, returnType, userdata,
+            (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
+            {
+                var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
+                SetValue(ref outputs[0], value);
+            });
+    }
+
+    private static ExtismValType ToExtismType<T>() where T : struct
+    {
+        return typeof(T) switch
         {
-            return typeof(T) switch
-            {
-                Type intType when intType == typeof(int) && val.t == ExtismValType.I32 => (T)(object)val.v.i32,
-                Type longType when longType == typeof(long) && val.t == ExtismValType.I64 => (T)(object)val.v.i64,
-                Type floatType when floatType == typeof(float) && val.t == ExtismValType.F32 => (T)(object)val.v.f32,
-                Type doubleType when doubleType == typeof(double) && val.t == ExtismValType.F64 => (T)(object)val.v.f64,
-                _ => throw new InvalidOperationException($"Unsupported conversion from {Enum.GetName(typeof(ExtismValType), val.t)} to {typeof(T).Name}")
-            };
-        }
+            Type t when t == typeof(int) || t == typeof(uint) => ExtismValType.I32,
+            Type t when t == typeof(long) || t == typeof(ulong) => ExtismValType.I64,
+            Type t when t == typeof(float) => ExtismValType.F32,
+            Type t when t == typeof(double) => ExtismValType.F64,
+            _ => throw new NotImplementedException($"Unsupported type: {typeof(T).Name}"),
+        };
+    }
 
-        private static void SetValue<T>(ref ExtismVal val, T t)
+    private static T GetValue<T>(ExtismVal val) where T : struct
+    {
+        return typeof(T) switch
         {
-            if (t is int i32)
-            {
-                val.t = ExtismValType.I32;
-                val.v.i32 = i32;
-            }
-            else if (t is uint u32)
-            {
-                val.t = ExtismValType.I32;
-                val.v.i32 = (int)u32;
-            }
-            else if (t is long i64)
-            {
-                val.t = ExtismValType.I64;
-                val.v.i64 = i64;
-            }
-            else if (t is ulong u64)
-            {
-                val.t = ExtismValType.I64;
-                val.v.i64 = (long)u64;
-            }
-            else if (t is float f32)
-            {
-                val.t = ExtismValType.F32;
-                val.v.f32 = f32;
-            }
-            else if (t is double f64)
-            {
-                val.t = ExtismValType.F64;
-                val.v.f64 = f64;
-            }
-            else
-            {
-                throw new InvalidOperationException($"Unsupported value type: {typeof(T).Name}");
-            }
-        }
+            Type intType when intType == typeof(int) && val.t == ExtismValType.I32 => (T)(object)val.v.i32,
+            Type longType when longType == typeof(long) && val.t == ExtismValType.I64 => (T)(object)val.v.i64,
+            Type floatType when floatType == typeof(float) && val.t == ExtismValType.F32 => (T)(object)val.v.f32,
+            Type doubleType when doubleType == typeof(double) && val.t == ExtismValType.F64 => (T)(object)val.v.f64,
+            _ => throw new InvalidOperationException($"Unsupported conversion from {Enum.GetName(typeof(ExtismValType), val.t)} to {typeof(T).Name}")
+        };
+    }
 
-        /// <summary>
-        /// Frees all resources held by this Host Function.
-        /// </summary>
-        public void Dispose()
+    private static void SetValue<T>(ref ExtismVal val, T t)
+    {
+        if (t is int i32)
         {
-            if (Interlocked.Exchange(ref _disposed, DisposedMarker) == DisposedMarker)
-            {
-                // Already disposed.
-                return;
-            }
-
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            val.t = ExtismValType.I32;
+            val.v.i32 = i32;
         }
-
-        /// <summary>
-        /// Throw an appropriate exception if the Host Function has been disposed.
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        protected void CheckNotDisposed()
+        else if (t is uint u32)
         {
-            Interlocked.MemoryBarrier();
-            if (_disposed == DisposedMarker)
-            {
-                ThrowDisposedException();
-            }
+            val.t = ExtismValType.I32;
+            val.v.i32 = (int)u32;
         }
-
-        [DoesNotReturn]
-        private static void ThrowDisposedException()
+        else if (t is long i64)
         {
-            throw new ObjectDisposedException(nameof(HostFunction));
+            val.t = ExtismValType.I64;
+            val.v.i64 = i64;
         }
-
-        /// <summary>
-        /// Frees all resources held by this Host Function.
-        /// </summary>
-        unsafe protected virtual void Dispose(bool disposing)
+        else if (t is ulong u64)
         {
-            if (disposing)
-            {
-                // Free up any managed resources here
-            }
-
-            // Free up unmanaged resources
-            extism_function_free(NativeHandle);
+            val.t = ExtismValType.I64;
+            val.v.i64 = (long)u64;
         }
-
-        /// <summary>
-        /// Destructs the current Host Function and frees all resources used by it.
-        /// </summary>
-        ~HostFunction()
+        else if (t is float f32)
         {
-            Dispose(false);
+            val.t = ExtismValType.F32;
+            val.v.f32 = f32;
         }
+        else if (t is double f64)
+        {
+            val.t = ExtismValType.F64;
+            val.v.f64 = f64;
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unsupported value type: {typeof(T).Name}");
+        }
+    }
+
+    /// <summary>
+    /// Frees all resources held by this Host Function.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, DisposedMarker) == DisposedMarker)
+        {
+            // Already disposed.
+            return;
+        }
+
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Throw an appropriate exception if the Host Function has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException"></exception>
+    protected void CheckNotDisposed()
+    {
+        Interlocked.MemoryBarrier();
+        if (_disposed == DisposedMarker)
+        {
+            ThrowDisposedException();
+        }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowDisposedException()
+    {
+        throw new ObjectDisposedException(nameof(HostFunction));
+    }
+
+    /// <summary>
+    /// Frees all resources held by this Host Function.
+    /// </summary>
+    unsafe protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Free up any managed resources here
+        }
+
+        // Free up unmanaged resources
+        LibExtism.extism_function_free(NativeHandle);
+    }
+
+    /// <summary>
+    /// Destructs the current Host Function and frees all resources used by it.
+    /// </summary>
+    ~HostFunction()
+    {
+        Dispose(false);
     }
 }

--- a/src/Extism.Sdk/LogLevel.cs
+++ b/src/Extism.Sdk/LogLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace Extism.Sdk.Native;
+﻿namespace Extism.Sdk;
 
 /// <summary>
 /// Extism Log Levels

--- a/src/Extism.Sdk/Plugin.cs
+++ b/src/Extism.Sdk/Plugin.cs
@@ -3,8 +3,9 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Extism.Sdk.Native;
 
-namespace Extism.Sdk.Native;
+namespace Extism.Sdk;
 
 /// <summary>
 /// Represents a WASM Extism plugin.

--- a/test/Extism.Sdk/Helpers.cs
+++ b/test/Extism.Sdk/Helpers.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Extism.Sdk.Native;
 
 namespace Extism.Sdk.Tests;
 

--- a/test/Extism.Sdk/ManifestTests.cs
+++ b/test/Extism.Sdk/ManifestTests.cs
@@ -1,4 +1,3 @@
-using Extism.Sdk.Native;
 using Shouldly;
 using System.Reflection;
 using System.Text;


### PR DESCRIPTION
Extism.Sdk.Native should only contain classes/structs/enums that are defined by the native runtime