### PR TITLE
feat: make the SDK AOT friendly

### DIFF
--- a/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
+++ b/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
@@ -7,6 +7,7 @@
 		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<PublishAot>true</PublishAot>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Extism.Sdk/Extism.Sdk.csproj
+++ b/src/Extism.Sdk/Extism.Sdk.csproj
@@ -1,13 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<LangVersion>11</LangVersion>
 		<MinVerTagPrefix>v</MinVerTagPrefix>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Extism.Sdk/Manifest.cs
+++ b/src/Extism.Sdk/Manifest.cs
@@ -3,6 +3,18 @@ using System.Text.Json;
 
 namespace Extism.Sdk
 {
+    [JsonSerializable(typeof(Manifest))]
+    [JsonSerializable(typeof(HttpMethod))]
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    [JsonSerializable(typeof(WasmSource))]
+    [JsonSerializable(typeof(ByteArrayWasmSource))]
+    [JsonSerializable(typeof(PathWasmSource))]
+    [JsonSerializable(typeof(UrlWasmSource))]
+    internal partial class ManifestJsonContext : JsonSerializerContext
+    {
+
+    }
+
     /// <summary>
     /// The manifest is a description of your plugin and some of the runtime constraints to apply to it.
     /// You can think of it as a blueprint to build your plugin.
@@ -101,7 +113,7 @@ namespace Extism.Sdk
         [JsonPropertyName("max_pages")]
         public int MaxPages { get; set; }
 
-        
+
         /// <summary>
         /// Max number of bytes allowed in an HTTP response when using extism_http_request.
         /// </summary>
@@ -285,14 +297,24 @@ namespace Extism.Sdk
 
         public override void Write(Utf8JsonWriter writer, WasmSource value, JsonSerializerOptions options)
         {
+            // Clone it because a JsonSerializerOptions can't be shared by multiple JsonSerializerContexts
+            var context = new ManifestJsonContext(new JsonSerializerOptions(options));
             if (value is PathWasmSource path)
-                JsonSerializer.Serialize(writer, path, typeof(PathWasmSource), options);
+            {
+                JsonSerializer.Serialize(writer, path, context.PathWasmSource);
+            }
             else if (value is ByteArrayWasmSource bytes)
-                JsonSerializer.Serialize(writer, bytes, typeof(ByteArrayWasmSource), options);
+            {
+                JsonSerializer.Serialize(writer, bytes, context.ByteArrayWasmSource);
+            }
             else if (value is UrlWasmSource uri)
-                JsonSerializer.Serialize(writer, uri, typeof(UrlWasmSource), options);
+            {
+                JsonSerializer.Serialize(writer, uri, context.UrlWasmSource);
+            }
             else
+            {
                 throw new ArgumentOutOfRangeException(nameof(value), "Unknown Wasm Source");
+            }
         }
     }
 


### PR DESCRIPTION
This PR makes the SDK AOT friendly by making sure we use Source Generator Json Serialization (instead of reflection). See:
 - https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/
 - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/fixing-warnings
 - https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/
 - https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming

Fixes #63 