### PR TITLE
fix: rename "header" => "headers" in manifest

### DIFF
--- a/src/Extism.Sdk/Manifest.cs
+++ b/src/Extism.Sdk/Manifest.cs
@@ -209,7 +209,7 @@ namespace Extism.Sdk
         /// <summary>
         /// HTTP headers
         /// </summary>
-        [JsonPropertyName("header")]
+        [JsonPropertyName("headers")]
         public Dictionary<string, string> Headers { get; set; } = new();
 
         /// <summary>

--- a/test/Extism.Sdk/Extism.Sdk.Tests.csproj
+++ b/test/Extism.Sdk/Extism.Sdk.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extism.runtime.all" Version="1.2.0" />
+    <PackageReference Include="Extism.runtime.all" Version="1.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.8.1" />


### PR DESCRIPTION
the latest version of the runtime no longer recognizes "header"