### PR TITLE
feat: bring library to feature parity with libextism v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v3.0.3
         with:
-           dotnet-version: 8.x
+           dotnet-version: 9.x
 
       - name: Test .NET Sdk
         run: |

--- a/Extism.sln
+++ b/Extism.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Extism.Sdk.Sample", "sample
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Extism.Sdk.FSharpSample", "samples\Extism.Sdk.FSharpSample\Extism.Sdk.FSharpSample.fsproj", "{FD564581-E6FA-4380-B5D0-A0423BBA05A9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Extism.Sdk.Benchmarks", "test\Extism.Sdk.Benchmarks\Extism.Sdk.Benchmarks.csproj", "{8F7C7762-2E72-40DA-9834-6A5CD6BDCDD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{FD564581-E6FA-4380-B5D0-A0423BBA05A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD564581-E6FA-4380-B5D0-A0423BBA05A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD564581-E6FA-4380-B5D0-A0423BBA05A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F7C7762-2E72-40DA-9834-6A5CD6BDCDD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F7C7762-2E72-40DA-9834-6A5CD6BDCDD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F7C7762-2E72-40DA-9834-6A5CD6BDCDD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F7C7762-2E72-40DA-9834-6A5CD6BDCDD3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -372,9 +372,9 @@ let hostFunc = new HostFunction(
 
 The userData object is preserved for the lifetime of the host function and can be retrieved in any call using `CurrentPlugin.GetUserData<T>()`. If no userData was provided, `GetUserData<T>()` will return the default value for type `T`.
 
-### Host Context 
+### Call Host Context 
 
-Host context provides a way to pass per-call context data when invoking a plugin function. This is useful when you need to provide data specific to a particular function call rather than data that persists across all calls.
+Call Host Context provides a way to pass per-call context data when invoking a plugin function. This is useful when you need to provide data specific to a particular function call rather than data that persists across all calls.
 
 C#:
 
@@ -386,7 +386,7 @@ var result = plugin.CallWithHostContext("function_name", inputData, context);
 // Access in host function
 void HostFunction(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs)
 {
-    var context = plugin.GetHostContext<Dictionary<string, object>>();
+    var context = plugin.GetCallHostContext<Dictionary<string, object>>();
     // Use context...
 }
 ```
@@ -402,7 +402,7 @@ let result = plugin.CallWithHostContext("function_name", inputData, context)
 
 // Access context in host function
 let hostFunction (plugin: CurrentPlugin) (inputs: Span<ExtismVal>) (outputs: Span<ExtismVal>) =
-    match plugin.GetHostContext<IDictionary<string, obj>>() with
+    match plugin.GetCallHostContext<IDictionary<string, obj>>() with
     | null -> printfn "No context available"
     | context -> 
         let requestId = context.["requestId"] :?> int
@@ -434,23 +434,13 @@ var plugin = new Plugin(manifest, functions, options);
 F#:
 
 ```fsharp
-// Create manifest and options
 let manifest = Manifest(PathWasmSource("/path/to/plugin.wasm"))
 let options = PluginIntializationOptions(
     FuelLimit = Nullable<int64>(1000L), // plugin can execute 1000 instructions
     WithWasi = true
 )
 
-// Create plugin with fuel limit
 use plugin = new Plugin(manifest, Array.empty<HostFunction>, options)
-
-// Handle potential fuel limit exception
-try
-    let result = plugin.Call("some_function", input)
-    printfn "%s" result
-with 
-| :? ExtismException as ex when ex.Message.Contains("fuel") -> 
-    printfn "Fuel limit exceeded: %s" ex.Message
 ```
 
 When the fuel limit is exceeded, the plugin execution is terminated and an `ExtismException` is thrown containing "fuel" in the error message.

--- a/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
+++ b/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Extism.runtime.win-x64" Version="1.4.1" />
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.8.0" />
 		<ProjectReference Include="..\..\src\Extism.Sdk\Extism.Sdk.csproj" />
 	</ItemGroup>
 

--- a/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
+++ b/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Extism.runtime.win-x64" Version="1.8.0" />
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.9.0" />
 		<ProjectReference Include="..\..\src\Extism.Sdk\Extism.Sdk.csproj" />
 	</ItemGroup>
 

--- a/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
+++ b/samples/Extism.Sdk.FSharpSample/Extism.Sdk.FSharpSample.fsproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
+++ b/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Extism.runtime.win-x64" Version="1.4.1" />
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.8.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
+++ b/samples/Extism.Sdk.Sample/Extism.Sdk.Sample.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Extism.runtime.win-x64" Version="1.8.0" />
+		<PackageReference Include="Extism.runtime.win-x64" Version="1.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Extism.Sdk.Sample/Program.cs
+++ b/samples/Extism.Sdk.Sample/Program.cs
@@ -1,5 +1,4 @@
 using Extism.Sdk;
-using Extism.Sdk.Native;
 
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -48,7 +48,7 @@ public unsafe class CurrentPlugin
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public T? GetHostContext<T>()
+    public T? GetCallHostContext<T>()
     {
         var ptr = LibExtism.extism_current_plugin_host_context(NativeHandle);
         if (ptr == null)

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -25,7 +25,7 @@ public unsafe class CurrentPlugin
     /// Returns the user data object that was passed in when a <see cref="HostFunction"/> was registered.
     /// </summary>
     [Obsolete("Use GetUserData<T> instead.")]
-    public IntPtr UserData => _userData;
+    public nint UserData => _userData;
 
     /// <summary>
     /// Returns the user data object that was passed in when a <see cref="HostFunction"/> was registered.

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -10,15 +10,22 @@ namespace Extism.Sdk;
 /// </summary>
 public unsafe class CurrentPlugin
 {
+    private readonly nint _userData;
     internal CurrentPlugin(LibExtism.ExtismCurrentPlugin* nativeHandle, nint userData)
     {
         NativeHandle = nativeHandle;
-        UserData = userData;
+
+
+        _userData = userData;
     }
 
     internal LibExtism.ExtismCurrentPlugin* NativeHandle { get; }
 
-    internal IntPtr UserData { get; set; }
+    /// <summary>
+    /// Returns the user data object that was passed in when a <see cref="HostFunction"/> was registered.
+    /// </summary>
+    [Obsolete("Use GetUserData<T> instead.")]
+    public IntPtr UserData => _userData;
 
     /// <summary>
     /// Returns the user data object that was passed in when a <see cref="HostFunction"/> was registered.
@@ -27,7 +34,7 @@ public unsafe class CurrentPlugin
     /// <returns></returns>
     public T? GetUserData<T>()
     {
-        var handle1 = GCHandle.FromIntPtr(UserData);
+        var handle1 = GCHandle.FromIntPtr(_userData);
         return (T?)handle1.Target;
     }
 

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -34,6 +34,11 @@ public unsafe class CurrentPlugin
     /// <returns></returns>
     public T? GetUserData<T>()
     {
+        if (_userData == IntPtr.Zero)
+        {
+            return default;
+        }
+
         var handle1 = GCHandle.FromIntPtr(_userData);
         return (T?)handle1.Target;
     }

--- a/src/Extism.Sdk/CurrentPlugin.cs
+++ b/src/Extism.Sdk/CurrentPlugin.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Runtime.InteropServices;
+using System.Text;
+
 using Extism.Sdk.Native;
 
 namespace Extism.Sdk;
@@ -6,20 +8,45 @@ namespace Extism.Sdk;
 /// <summary>
 /// Represents the current plugin. Can only be used within <see cref="HostFunction"/>s.
 /// </summary>
-public class CurrentPlugin
+public unsafe class CurrentPlugin
 {
-    internal CurrentPlugin(long nativeHandle, nint userData)
+    internal CurrentPlugin(LibExtism.ExtismCurrentPlugin* nativeHandle, nint userData)
     {
         NativeHandle = nativeHandle;
         UserData = userData;
     }
 
-    internal long NativeHandle { get; }
+    internal LibExtism.ExtismCurrentPlugin* NativeHandle { get; }
+
+    internal IntPtr UserData { get; set; }
 
     /// <summary>
-    /// An opaque pointer to an object from the host, passed in when a <see cref="HostFunction"/> is registered.
+    /// Returns the user data object that was passed in when a <see cref="HostFunction"/> was registered.
     /// </summary>
-    public nint UserData { get; set; }
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public T? GetUserData<T>()
+    {
+        var handle1 = GCHandle.FromIntPtr(UserData);
+        return (T?)handle1.Target;
+    }
+
+    /// <summary>
+    /// Get the current plugin call's associated host context data. Returns null if call was made without host context.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public T? GetHostContext<T>()
+    {
+        var ptr = LibExtism.extism_current_plugin_host_context(NativeHandle);
+        if (ptr == null)
+        {
+            return default;
+        }
+
+        var handle = GCHandle.FromIntPtr(new IntPtr(ptr));
+        return (T?)handle.Target;
+    }
 
     /// <summary>
     /// Returns a offset to the memory of the currently running plugin.

--- a/src/Extism.Sdk/Extism.Sdk.csproj
+++ b/src/Extism.Sdk/Extism.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net7.0;net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/Extism.Sdk/HostFunction.cs
+++ b/src/Extism.Sdk/HostFunction.cs
@@ -1,5 +1,6 @@
 ﻿using Extism.Sdk.Native;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace Extism.Sdk;
 
@@ -20,6 +21,7 @@ public class HostFunction : IDisposable
     private int _disposed;
     private readonly ExtismFunction _function;
     private readonly LibExtism.InternalExtismFunction _callback;
+    private readonly GCHandle _userDataHandle;
 
     /// <summary>
     /// Registers a Host Function.
@@ -27,24 +29,34 @@ public class HostFunction : IDisposable
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
     /// <param name="inputTypes">The types of the input arguments/parameters the <see cref="Plugin"/> caller will provide.</param>
     /// <param name="outputTypes">The types of the output returned from the host function to the <see cref="Plugin"/>.</param>
-    /// <param name="userData">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="hostFunction"></param>
     unsafe public HostFunction(
         string functionName,
         Span<ExtismValType> inputTypes,
         Span<ExtismValType> outputTypes,
-        nint userData,
+        object userData,
         ExtismFunction hostFunction)
     {
-        // Make sure we store the delegate referene in a field so that it doesn't get garbage collected
+        // Make sure we store the delegate reference in a field so that it doesn't get garbage collected
         _function = hostFunction;
         _callback = CallbackImpl;
+        _userDataHandle = GCHandle.Alloc(userData);
 
         fixed (ExtismValType* inputs = inputTypes)
         fixed (ExtismValType* outputs = outputTypes)
         {
-            NativeHandle = LibExtism.extism_function_new(functionName, inputs, inputTypes.Length, outputs, outputTypes.Length, _callback, userData, IntPtr.Zero);
+            NativeHandle = LibExtism.extism_function_new(
+                functionName, 
+                inputs, 
+                inputTypes.Length, 
+                outputs, 
+                outputTypes.Length,
+                _callback, 
+                GCHandle.ToIntPtr(_userDataHandle), 
+                IntPtr.Zero);
         }
     }
 
@@ -74,7 +86,7 @@ public class HostFunction : IDisposable
     }
 
     private unsafe void CallbackImpl(
-        long plugin,
+        LibExtism.ExtismCurrentPlugin* plugin,
         ExtismVal* inputsPtr,
         uint n_inputs,
         ExtismVal* outputsPtr,
@@ -91,19 +103,20 @@ public class HostFunction : IDisposable
     /// Registers a <see cref="HostFunction"/> from a method that takes no parameters an returns no values.
     /// </summary>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod(
         string functionName,
-        nint userdata,
+        object userData,
         Action<CurrentPlugin> callback)
     {
         var inputTypes = new ExtismValType[] { };
         var returnType = new ExtismValType[] { };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 callback(plugin);
@@ -116,20 +129,21 @@ public class HostFunction : IDisposable
     /// </summary>
     /// <typeparam name="I1">Type of first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1>(
         string functionName,
-        nint userdata,
+        object userData,
         Action<CurrentPlugin, I1> callback)
         where I1 : struct
     {
         var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
         var returnType = new ExtismValType[] { };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 callback(plugin, GetValue<I1>(inputs[0]));
@@ -143,13 +157,14 @@ public class HostFunction : IDisposable
     /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1, I2>(
         string functionName,
-        nint userdata,
+        object userData,
         Action<CurrentPlugin, I1, I2> callback)
         where I1 : struct
         where I2 : struct
@@ -158,7 +173,7 @@ public class HostFunction : IDisposable
 
         var returnType = new ExtismValType[] { };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
@@ -173,13 +188,14 @@ public class HostFunction : IDisposable
     /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1, I2, I3>(
         string functionName,
-        nint userdata,
+        object userData,
         Action<CurrentPlugin, I1, I2, I3> callback)
         where I1 : struct
         where I2 : struct
@@ -188,7 +204,7 @@ public class HostFunction : IDisposable
         var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
         var returnType = new ExtismValType[] { };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
@@ -201,20 +217,21 @@ public class HostFunction : IDisposable
     /// </summary>
     /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<R>(
         string functionName,
-        nint userdata,
+        object userData,
         Func<CurrentPlugin, R> callback)
         where R : struct
     {
         var inputTypes = new ExtismValType[] { };
         var returnType = new ExtismValType[] { ToExtismType<R>() };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 var value = callback(plugin);
@@ -229,13 +246,14 @@ public class HostFunction : IDisposable
     /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1, R>(
         string functionName,
-        nint userdata,
+        object userData,
         Func<CurrentPlugin, I1, R> callback)
         where I1 : struct
         where R : struct
@@ -243,7 +261,7 @@ public class HostFunction : IDisposable
         var inputTypes = new ExtismValType[] { ToExtismType<I1>() };
         var returnType = new ExtismValType[] { ToExtismType<R>() };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 var value = callback(plugin, GetValue<I1>(inputs[0]));
@@ -259,13 +277,14 @@ public class HostFunction : IDisposable
     /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1, I2, R>(
         string functionName,
-        nint userdata,
+        object userData,
         Func<CurrentPlugin, I1, I2, R> callback)
         where I1 : struct
         where I2 : struct
@@ -274,7 +293,7 @@ public class HostFunction : IDisposable
         var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>() };
         var returnType = new ExtismValType[] { ToExtismType<R>() };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]));
@@ -291,13 +310,14 @@ public class HostFunction : IDisposable
     /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <typeparam name="R">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
     /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="userData">
+    /// A state object that will be preserved and can be retrieved during function execution using <see cref="CurrentPlugin.GetUserData{T}"/>. 
+    /// This allows you to maintain context between function calls.</param>
     /// <param name="callback">The host function implementation.</param>
     /// <returns></returns>
     public static HostFunction FromMethod<I1, I2, I3, R>(
         string functionName,
-        nint userdata,
+        object userData,
         Func<CurrentPlugin, I1, I2, I3, R> callback)
         where I1 : struct
         where I2 : struct
@@ -307,7 +327,7 @@ public class HostFunction : IDisposable
         var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
         var returnType = new ExtismValType[] { ToExtismType<R>() };
 
-        return new HostFunction(functionName, inputTypes, returnType, userdata,
+        return new HostFunction(functionName, inputTypes, returnType, userData,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
             {
                 var value = callback(plugin, GetValue<I1>(inputs[0]), GetValue<I2>(inputs[1]), GetValue<I3>(inputs[2]));
@@ -418,7 +438,7 @@ public class HostFunction : IDisposable
     {
         if (disposing)
         {
-            // Free up any managed resources here
+            _userDataHandle.Free();
         }
 
         // Free up unmanaged resources

--- a/src/Extism.Sdk/HostFunction.cs
+++ b/src/Extism.Sdk/HostFunction.cs
@@ -62,27 +62,27 @@ public class HostFunction : IDisposable
         }
     }
 
-        /// <summary>
-        /// Sets the function namespace. By default it's set to `extism:host/user`.
-        /// </summary>
-        /// <param name="ns"></param>
-        /// <returns></returns>
-        public HostFunction WithNamespace(string ns)
-        {
-            this.SetNamespace(ns);
-            return this;
-        }
+    /// <summary>
+    /// Sets the function namespace. By default it's set to `extism:host/user`.
+    /// </summary>
+    /// <param name="ns"></param>
+    /// <returns></returns>
+    public HostFunction WithNamespace(string ns)
+    {
+        this.SetNamespace(ns);
+        return this;
+    }
 
-        private unsafe void CallbackImpl(
-            long plugin,
-            ExtismVal* inputsPtr,
-            uint n_inputs,
-            ExtismVal* outputsPtr,
-            uint n_outputs,
-            nint data)
-        {
-            var outputs = new Span<ExtismVal>(outputsPtr, (int)n_outputs);
-            var inputs = new Span<ExtismVal>(inputsPtr, (int)n_inputs);
+    private unsafe void CallbackImpl(
+        long plugin,
+        ExtismVal* inputsPtr,
+        uint n_inputs,
+        ExtismVal* outputsPtr,
+        uint n_outputs,
+        nint data)
+    {
+        var outputs = new Span<ExtismVal>(outputsPtr, (int)n_outputs);
+        var inputs = new Span<ExtismVal>(inputsPtr, (int)n_inputs);
 
         _function(new CurrentPlugin(plugin, data), inputs, outputs);
     }
@@ -165,28 +165,28 @@ public class HostFunction : IDisposable
             });
     }
 
-        /// <summary>
-        /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameters an returns no values. Supported parameter types:
-        /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
-        /// </summary>
-        /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
-        /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
-        /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
-        /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
-        /// <param name="callback">The host function implementation.</param>
-        /// <returns></returns>
-        public static HostFunction FromMethod<I1, I2, I3>(
-            string functionName,
-            nint userdata,
-            Action<CurrentPlugin, I1, I2, I3> callback)
-            where I1 : struct
-            where I2 : struct
-            where I3 : struct
-        {
-            var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
-            var returnType = new ExtismValType[] { };
+    /// <summary>
+    /// Registers a <see cref="HostFunction"/> from a method that takes 3 parameters an returns no values. Supported parameter types:
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>
+    /// </summary>
+    /// <typeparam name="I1">Type of the first parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I2">Type of the second parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <typeparam name="I3">Type of the third parameter. Supported parameter types: <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/></typeparam>
+    /// <param name="functionName">The literal name of the function, how it would be called from a <see cref="Plugin"/>.</param>
+    /// <param name="userdata">An opaque pointer to an object from the host, accessible on <see cref="CurrentPlugin"/>.
+    /// NOTE: it is the shared responsibility of the host and <see cref="Plugin"/> to cast/dereference this value properly.</param>
+    /// <param name="callback">The host function implementation.</param>
+    /// <returns></returns>
+    public static HostFunction FromMethod<I1, I2, I3>(
+        string functionName,
+        nint userdata,
+        Action<CurrentPlugin, I1, I2, I3> callback)
+        where I1 : struct
+        where I2 : struct
+        where I3 : struct
+    {
+        var inputTypes = new ExtismValType[] { ToExtismType<I1>(), ToExtismType<I2>(), ToExtismType<I3>() };
+        var returnType = new ExtismValType[] { };
 
         return new HostFunction(functionName, inputTypes, returnType, userdata,
             (CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs) =>
@@ -364,12 +364,12 @@ public class HostFunction : IDisposable
         else if (t is float f32)
         {
             val.t = ExtismValType.F32;
-            val.v.f32 = BitConverter.SingleToInt32Bits(f32);
+            val.v.f32 = f32;
         }
         else if (t is double f64)
         {
             val.t = ExtismValType.F64;
-            val.v.f64 = BitConverter.DoubleToInt64Bits(f64);
+            val.v.f64 = f64;
         }
         else
         {

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -208,6 +208,20 @@ internal static class LibExtism
     unsafe internal static extern ExtismPlugin* extism_plugin_new(byte* wasm, long wasmSize, IntPtr* functions, long nFunctions, [MarshalAs(UnmanagedType.I1)] bool withWasi, out char** errmsg);
 
     /// <summary>
+    /// Load a WASM plugin with fuel limit.
+    /// </summary>
+    /// <param name="wasm">A WASM module (wat or wasm) or a JSON encoded manifest.</param>
+    /// <param name="wasmSize">The length of the `wasm` parameter.</param>
+    /// <param name="functions">Array of host function pointers.</param>
+    /// <param name="nFunctions">Number of host functions.</param>
+    /// <param name="withWasi">Enables/disables WASI.</param>
+    /// <param name="fuelLimit">Max number of instructions that can be executed by the plugin.</param>
+    /// <param name="errmsg"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern ExtismPlugin* extism_plugin_new_with_fuel_limit(byte* wasm, long wasmSize, IntPtr* functions, long nFunctions, [MarshalAs(UnmanagedType.I1)] bool withWasi, long fuelLimit, out char** errmsg);
+
+    /// <summary>
     /// Frees a plugin error message.
     /// </summary>
     /// <param name="errorMessage"></param>

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -113,6 +113,9 @@ internal static class LibExtism
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExtismPlugin { }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ExtismCompiledPlugin { }
+
     /// <summary>
     /// Host function signature
     /// </summary>
@@ -217,6 +220,32 @@ internal static class LibExtism
     /// <param name="plugin">Pointer to the plugin you want to free.</param>
     [DllImport("extism")]
     unsafe internal static extern void extism_plugin_free(ExtismPlugin* plugin);
+    /// <summary>
+    /// Pre-compile an Extism plugin
+    /// </summary>
+    /// <param name="wasm">A WASM module (wat or wasm) or a JSON encoded manifest.</param>
+    /// <param name="wasmSize">The length of the `wasm` parameter.</param>
+    /// <param name="functions">Array of host function pointers.</param>
+    /// <param name="nFunctions">Number of host functions.</param>
+    /// <param name="withWasi">Enables/disables WASI.</param>
+    /// <param name="errmsg"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern ExtismCompiledPlugin* extism_compiled_plugin_new(byte* wasm, long wasmSize, IntPtr* functions, long nFunctions, [MarshalAs(UnmanagedType.I1)] bool withWasi, out char** errmsg);
+
+    /// <summary>
+    /// Free `ExtismCompiledPlugin`
+    /// </summary>
+    /// <param name="plugin"></param>
+    [DllImport("extism")]
+    unsafe internal static extern void extism_compiled_plugin_free(ExtismCompiledPlugin* plugin);
+
+    /// <summary>
+    ///  Create a new plugin from an `ExtismCompiledPlugin`
+    /// </summary>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern ExtismPlugin* extism_plugin_new_from_compiled(ExtismCompiledPlugin* compiled, out char** errmsg);
 
     /// <summary>
     /// Get handle for plugin cancellation

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -116,6 +116,9 @@ internal static class LibExtism
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExtismCompiledPlugin { }
 
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ExtismCurrentPlugin { }
+
     /// <summary>
     /// Host function signature
     /// </summary>
@@ -125,7 +128,7 @@ internal static class LibExtism
     /// <param name="outputs"></param>
     /// <param name="n_outputs"></param>
     /// <param name="data"></param>
-    unsafe internal delegate void InternalExtismFunction(long plugin, ExtismVal* inputs, uint n_inputs, ExtismVal* outputs, uint n_outputs, IntPtr data);
+    unsafe internal delegate void InternalExtismFunction(ExtismCurrentPlugin* plugin, ExtismVal* inputs, uint n_inputs, ExtismVal* outputs, uint n_outputs, IntPtr data);
 
     /// <summary>
     /// Returns a pointer to the memory of the currently running plugin.
@@ -134,7 +137,7 @@ internal static class LibExtism
     /// <param name="plugin"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory")]
-    internal static extern long extism_current_plugin_memory(long plugin);
+    unsafe internal static extern long extism_current_plugin_memory(ExtismCurrentPlugin* plugin);
 
     /// <summary>
     /// Allocate a memory block in the currently running plugin
@@ -143,7 +146,7 @@ internal static class LibExtism
     /// <param name="n"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_alloc")]
-    internal static extern long extism_current_plugin_memory_alloc(long plugin, long n);
+    unsafe internal static extern long extism_current_plugin_memory_alloc(ExtismCurrentPlugin* plugin, long n);
 
     /// <summary>
     /// Get the length of an allocated block.
@@ -153,7 +156,7 @@ internal static class LibExtism
     /// <param name="n"></param>
     /// <returns></returns>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_length")]
-    internal static extern long extism_current_plugin_memory_length(long plugin, long n);
+    unsafe internal static extern long extism_current_plugin_memory_length(ExtismCurrentPlugin* plugin, long n);
 
     /// <summary>
     /// Get the length of an allocated block.
@@ -162,7 +165,7 @@ internal static class LibExtism
     /// <param name="plugin"></param>
     /// <param name="ptr"></param>
     [DllImport("extism", EntryPoint = "extism_current_plugin_memory_free")]
-    internal static extern void extism_current_plugin_memory_free(long plugin, long ptr);
+    unsafe internal static extern void extism_current_plugin_memory_free(ExtismCurrentPlugin* plugin, long ptr);
 
     /// <summary>
     /// Create a new host function.
@@ -314,6 +317,26 @@ internal static class LibExtism
     /// <returns></returns>
     [DllImport("extism")]
     unsafe internal static extern int extism_plugin_call(ExtismPlugin* plugin, string funcName, byte* data, int dataLen);
+
+    /// <summary>
+    /// Call a function with host context.
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <param name="funcName">The function to call.</param>
+    /// <param name="data">Input data.</param>
+    /// <param name="dataLen">The length of the `data` parameter.</param>
+    /// <param name="hostContext">a pointer to context data that will be available in host functions</param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern int extism_plugin_call_with_host_context(ExtismPlugin* plugin, string funcName, byte* data, long dataLen, IntPtr hostContext);
+
+    /// <summary>
+    /// Get the current plugin's associated host context data. Returns null if call was made without host context.
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern void* extism_current_plugin_host_context(ExtismCurrentPlugin* plugin);
 
     /// <summary>
     /// Get the error associated with a Plugin

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -262,6 +262,14 @@ internal static class LibExtism
     unsafe internal static extern ExtismPlugin* extism_plugin_new_from_compiled(ExtismCompiledPlugin* compiled, out char** errmsg);
 
     /// <summary>
+    /// Enable HTTP response headers in plugins using `extism:host/env::http_request`
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern ExtismPlugin* extism_plugin_allow_http_response_headers(ExtismPlugin* plugin);
+
+    /// <summary>
     /// Get handle for plugin cancellation
     /// </summary>
     /// <param name="plugin"></param>

--- a/src/Extism.Sdk/LibExtism.cs
+++ b/src/Extism.Sdk/LibExtism.cs
@@ -340,6 +340,22 @@ internal static class LibExtism
     unsafe internal static extern IntPtr extism_plugin_output_data(ExtismPlugin* plugin);
 
     /// <summary>
+    /// Reset the Extism runtime, this will invalidate all allocated memory
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern bool extism_plugin_reset(ExtismPlugin* plugin);
+
+    /// <summary>
+    /// Get a plugin's ID, the returned bytes are a 16 byte buffer that represent a UUIDv4
+    /// </summary>
+    /// <param name="plugin"></param>
+    /// <returns></returns>
+    [DllImport("extism")]
+    unsafe internal static extern byte* extism_plugin_id(ExtismPlugin* plugin);
+
+    /// <summary>
     /// Set log file and level for file logger.
     /// </summary>
     /// <param name="filename"></param>

--- a/src/Extism.Sdk/Plugin.cs
+++ b/src/Extism.Sdk/Plugin.cs
@@ -145,6 +145,14 @@ public unsafe class Plugin : IDisposable
     }
 
     /// <summary>
+    /// Enable HTTP response headers in plugins using `extism:host/env::http_request`
+    /// </summary>
+    public void AllowHttpResponseHeaders()
+    {
+        LibExtism.extism_plugin_allow_http_response_headers(NativeHandle);
+    }
+
+    /// <summary>
     /// Update plugin config values, this will merge with the existing values.
     /// </summary>
     /// <param name="value"></param>

--- a/src/Extism.Sdk/Plugin.cs
+++ b/src/Extism.Sdk/Plugin.cs
@@ -145,6 +145,28 @@ public unsafe class Plugin : IDisposable
     }
 
     /// <summary>
+    /// Get the plugin's ID.
+    /// </summary>
+    public Guid Id
+    {
+        get
+        {
+            var bytes = new Span<byte>(LibExtism.extism_plugin_id(NativeHandle), 16);
+            return new Guid(bytes);
+        }
+    }
+
+    /// <summary>
+    /// Reset the Extism runtime, this will invalidate all allocated memory
+    /// </summary>
+    /// <returns></returns>
+    public bool Reset()
+    {
+        CheckNotDisposed();
+        return LibExtism.extism_plugin_reset(NativeHandle);
+    }
+
+    /// <summary>
     /// Enable HTTP response headers in plugins using `extism:host/env::http_request`
     /// </summary>
     public void AllowHttpResponseHeaders()

--- a/src/Extism.Sdk/Plugin.cs
+++ b/src/Extism.Sdk/Plugin.cs
@@ -236,7 +236,7 @@ public unsafe class Plugin : IDisposable
     /// <param name="cancellationToken">CancellationToken used for cancelling the Extism call.</param>
     /// <returns>The output of the function call</returns>
     /// <exception cref="ExtismException"></exception>
-    unsafe public ReadOnlySpan<byte> Call<T>(string functionName, ReadOnlySpan<byte> input, T hostContext, CancellationToken? cancellationToken = null)
+    unsafe public ReadOnlySpan<byte> CallWithHostContext<T>(string functionName, ReadOnlySpan<byte> input, T hostContext, CancellationToken? cancellationToken = null)
     {
         GCHandle handle = GCHandle.Alloc(hostContext);
         try

--- a/test/Extism.Sdk.Benchmarks/Extism.Sdk.Benchmarks.csproj
+++ b/test/Extism.Sdk.Benchmarks/Extism.Sdk.Benchmarks.csproj
@@ -5,13 +5,14 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-		<PublishAot>true</PublishAot>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\wasm\*.wasm">
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../../wasm/*.wasm" Link="wasm/%(Filename)%(Extension)">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
@@ -21,8 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\src\Extism.Sdk\Extism.Sdk.csproj" />
+		<ProjectReference Include="..\src\Extism.Sdk\Extism.Sdk.csproj" />
 	</ItemGroup>
-
 
 </Project>

--- a/test/Extism.Sdk.Benchmarks/Extism.Sdk.Benchmarks.csproj
+++ b/test/Extism.Sdk.Benchmarks/Extism.Sdk.Benchmarks.csproj
@@ -22,7 +22,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\src\Extism.Sdk\Extism.Sdk.csproj" />
+	  <ProjectReference Include="..\..\src\Extism.Sdk\Extism.Sdk.csproj" />
 	</ItemGroup>
+
 
 </Project>

--- a/test/Extism.Sdk.Benchmarks/Program.cs
+++ b/test/Extism.Sdk.Benchmarks/Program.cs
@@ -1,0 +1,51 @@
+﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Attributes;
+
+using Extism.Sdk;
+
+using System.Reflection;
+
+var summary = BenchmarkRunner.Run<CompiledPluginBenchmarks>();
+
+public class CompiledPluginBenchmarks
+{
+    private const int N = 1000;
+    private const string _input = "Hello, World!";
+    private const string _function = "count_vowels";
+    private readonly Manifest _manifest;
+
+    public CompiledPluginBenchmarks()
+    {
+        var binDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        _manifest = new Manifest(new PathWasmSource(Path.Combine(binDirectory, "wasm", "code.wasm"), "main"));
+    }
+
+    [Benchmark]
+    public void CompiledPluginInstantiate()
+    {
+        using var compiledPlugin = new CompiledPlugin(_manifest, [], withWasi: true);
+
+        for (var i = 0; i < N; i++)
+        {
+            using var plugin = compiledPlugin.Instantiate();
+            var response = plugin.Call(_function, _input);
+        }
+    }
+
+    [Benchmark]
+    public void PluginInstantiate()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            using var plugin = new Plugin(_manifest, [], withWasi: true);
+            var response = plugin.Call(_function, _input);
+        }
+    }
+}
+
+public class CountVowelsResponse
+{
+    public int Count { get; set; }
+    public int Total { get; set; }
+    public string? Vowels { get; set; }
+}

--- a/test/Extism.Sdk/BasicTests.cs
+++ b/test/Extism.Sdk/BasicTests.cs
@@ -180,6 +180,18 @@ public class BasicTests
         Encoding.UTF8.GetString(response).ShouldBe("HELLO FRODO!");
     }
 
+    [Fact]
+    public void FuelLimit()
+    {
+        using var plugin = Helpers.LoadPlugin("loop.wasm", options: new PluginIntializationOptions
+        {
+            FuelLimit = 1000,
+            WithWasi = true
+        });
+
+        Should.Throw<ExtismException>(() => plugin.Call("loop_forever", Array.Empty<byte>()))
+            .Message.ShouldContain("fuel");
+    }
 
     //[Fact]
     // flakey

--- a/test/Extism.Sdk/BasicTests.cs
+++ b/test/Extism.Sdk/BasicTests.cs
@@ -19,6 +19,14 @@ public class BasicTests
     }
 
     [Fact]
+    public void GetId()
+    {
+        using var plugin = Helpers.LoadPlugin("alloc.wasm");
+        var id = plugin.Id;
+        Assert.NotEqual(Guid.Empty, id);
+    }
+
+    [Fact]
     public void Fail()
     {
         using var plugin = Helpers.LoadPlugin("fail.wasm");

--- a/test/Extism.Sdk/BasicTests.cs
+++ b/test/Extism.Sdk/BasicTests.cs
@@ -191,7 +191,7 @@ public class BasicTests
                 { "answer", 42 }
             };
 
-            var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"), dict);
+            var response = plugin.CallWithHostContext("count_vowels", Encoding.UTF8.GetBytes("Hello World"), dict);
             Encoding.UTF8.GetString(response).ShouldBe("{\"count\": 3}");
         }
 
@@ -238,7 +238,7 @@ public class BasicTests
                 { "answer", 42 }
             };
 
-            var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"), dict);
+            var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"));
             Encoding.UTF8.GetString(response).ShouldBe("{\"count\": 3}");
         }
 

--- a/test/Extism.Sdk/BasicTests.cs
+++ b/test/Extism.Sdk/BasicTests.cs
@@ -202,7 +202,7 @@ public class BasicTests
             var text = plugin.GetUserData<string>();
             Assert.Equal("Hello again!", text);
 
-            var context = plugin.GetHostContext<Dictionary<string, object>>();
+            var context = plugin.GetCallHostContext<Dictionary<string, object>>();
             if (context is null || !context.ContainsKey("answer"))
             {
                 throw new InvalidOperationException("Context not found");

--- a/test/Extism.Sdk/CompiledPluginTests.cs
+++ b/test/Extism.Sdk/CompiledPluginTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Xunit;
+
+using static Extism.Sdk.Tests.BasicTests;
+
+namespace Extism.Sdk.Tests;
+
+public class CompiledPluginTests
+{
+    [Fact]
+    public void CountVowels()
+    {
+        using var compiledPlugin = Helpers.CompilePlugin("code.wasm");
+
+        for (var i = 0; i < 3; i++)
+        {
+            using var plugin = compiledPlugin.Instantiate();
+
+            var response = plugin.Call<CountVowelsResponse>("count_vowels", "Hello World");
+
+            response.ShouldNotBeNull();
+            response.Count.ShouldBe(3);
+        }
+    }
+
+    [Fact]
+    public void CountVowelsHostFunctions()
+    {
+        var userData = Marshal.StringToHGlobalAnsi("Hello again!");
+        using var helloWorld = HostFunction.FromMethod<long, long>("hello_world", userData, HelloWorld);
+
+        using var compiledPlugin = Helpers.CompilePlugin("code-functions.wasm", null, helloWorld);
+        for (int i = 0; i < 3; i++)
+        {
+            using var plugin = compiledPlugin.Instantiate();
+
+            var response = plugin.Call("count_vowels", Encoding.UTF8.GetBytes("Hello World"));
+            Encoding.UTF8.GetString(response).ShouldBe("{\"count\": 3}");
+        }
+
+        long HelloWorld(CurrentPlugin plugin, long ptr)
+        {
+            Console.WriteLine("Hello from .NET!");
+
+            var text = Marshal.PtrToStringAnsi(plugin.UserData);
+            Console.WriteLine(text);
+
+            var input = plugin.ReadString(ptr);
+            Console.WriteLine($"Input: {input}");
+
+            return plugin.WriteString(new string(input)); // clone the string
+        }
+    }
+
+}

--- a/test/Extism.Sdk/CompiledPluginTests.cs
+++ b/test/Extism.Sdk/CompiledPluginTests.cs
@@ -30,7 +30,7 @@ public class CompiledPluginTests
     [Fact]
     public void CountVowelsHostFunctions()
     {
-        var userData = Marshal.StringToHGlobalAnsi("Hello again!");
+        var userData = "Hello again!";
         using var helloWorld = HostFunction.FromMethod<long, long>("hello_world", userData, HelloWorld);
 
         using var compiledPlugin = Helpers.CompilePlugin("code-functions.wasm", null, helloWorld);
@@ -46,7 +46,7 @@ public class CompiledPluginTests
         {
             Console.WriteLine("Hello from .NET!");
 
-            var text = Marshal.PtrToStringAnsi(plugin.UserData);
+            var text = plugin.GetUserData<string>();
             Console.WriteLine(text);
 
             var input = plugin.ReadString(ptr);

--- a/test/Extism.Sdk/Extism.Sdk.Tests.csproj
+++ b/test/Extism.Sdk/Extism.Sdk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Extism.Sdk/Extism.Sdk.Tests.csproj
+++ b/test/Extism.Sdk/Extism.Sdk.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extism.runtime.all" Version="1.4.1" />
+    <PackageReference Include="Extism.runtime.all" Version="1.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/test/Extism.Sdk/Helpers.cs
+++ b/test/Extism.Sdk/Helpers.cs
@@ -4,7 +4,7 @@ namespace Extism.Sdk.Tests;
 
 public static class Helpers
 {
-    public static Plugin LoadPlugin(string name, Action<Manifest>? config = null, params HostFunction[] hostFunctions)
+    public static Plugin LoadPlugin(string name, PluginIntializationOptions options, Action<Manifest>? config = null, params HostFunction[] hostFunctions)
     {
         var binDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         var manifest = new Manifest(new PathWasmSource(Path.Combine(binDirectory, "wasm", name), "main"));
@@ -14,7 +14,15 @@ public static class Helpers
             config(manifest);
         }
 
-        return new Plugin(manifest, hostFunctions, withWasi: true);
+        return new Plugin(manifest, hostFunctions, options);
+    }
+
+    public static Plugin LoadPlugin(string name, Action<Manifest>? config = null, params HostFunction[] hostFunctions)
+    {
+        return LoadPlugin(name, new PluginIntializationOptions
+        {
+            WithWasi = true,
+        }, config, hostFunctions);
     }
 
     public static CompiledPlugin CompilePlugin(string name, Action<Manifest>? config = null, params HostFunction[] hostFunctions)

--- a/test/Extism.Sdk/Helpers.cs
+++ b/test/Extism.Sdk/Helpers.cs
@@ -16,4 +16,16 @@ public static class Helpers
 
         return new Plugin(manifest, hostFunctions, withWasi: true);
     }
+
+    public static CompiledPlugin CompilePlugin(string name, Action<Manifest>? config = null, params HostFunction[] hostFunctions)
+    {
+        var binDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var manifest = new Manifest(new PathWasmSource(Path.Combine(binDirectory, "wasm", name), "main"));
+        if (config is not null)
+        {
+            config(manifest);
+        }
+
+        return new CompiledPlugin(manifest, hostFunctions, withWasi: true);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dylibso/xtp/issues/955

This updates the sample apps to use the latest libextism version

- [x] CompiledPlugin
- [x] Fuel limit support
- [x] HTTP Response headers
- [x] Plugin Reset
- [x] Plugin ID access
- [x] Host Context in plugin calls
- [x] Update docs


Questions:
1. Do we need a `extism_compiled_plugin_new_error_free` function (similar to `extism_plugin_new_error_free`)?
2. Did we cahnge how we're representing/reading f32/f64 values?
3. ~~Breaking changes to `CurrentPlugin.UserData`~~